### PR TITLE
Add mail alias lifecycle parity

### DIFF
--- a/modules/control-panel-dns-api/openapi/v1/control-panel-dns.yaml
+++ b/modules/control-panel-dns-api/openapi/v1/control-panel-dns.yaml
@@ -22,6 +22,11 @@ paths:
       responses: {'201': {description: Zone created}}
   /api/v1/control-panel/dns/records:
     post: {operationId: control.panel.dns.records.create, security: [{sanctum: []}], responses: {'201': {description: DNS record created}}}
+  /api/v1/control-panel/dns/records/validate:
+    post:
+      operationId: control.panel.dns.records.validate
+      security: [{sanctum: []}]
+      responses: {'200': {description: DNS record validation result}}
   /api/v1/control-panel/dns/checks:
     post: {operationId: control.panel.dns.checks.create, security: [{sanctum: []}], responses: {'201': {description: DNS validation check recorded}}}
   /api/v1/control-panel/dns/features:

--- a/modules/control-panel-dns-api/routes/api.php
+++ b/modules/control-panel-dns-api/routes/api.php
@@ -10,6 +10,7 @@ Route::prefix('api/v1/control-panel/dns')->middleware(['api', 'auth:sanctum', 't
     Route::post('/zones', [ZoneController::class, 'store'])->name('control-panel.dns.zones.store');
     Route::patch('/zones/{zone}', [ZoneController::class, 'update'])->name('control-panel.dns.zones.update');
     Route::post('/records', [ZoneController::class, 'record'])->name('control-panel.dns.records.store');
+    Route::post('/records/validate', [ZoneController::class, 'validateRecord'])->name('control-panel.dns.records.validate');
     Route::patch('/records/{record}', [ZoneController::class, 'updateRecord'])->name('control-panel.dns.records.update');
     Route::delete('/records/{record}', [ZoneController::class, 'deleteRecord'])->name('control-panel.dns.records.delete');
     Route::post('/records/bulk', [ZoneController::class, 'bulkRecords'])->name('control-panel.dns.records.bulk');

--- a/modules/control-panel-dns-api/src/Http/Controllers/ZoneController.php
+++ b/modules/control-panel-dns-api/src/Http/Controllers/ZoneController.php
@@ -16,6 +16,7 @@ use Liberu\ControlPanel\Dns\Actions\RegisterDnsFeature;
 use Liberu\ControlPanel\Dns\Actions\SuspendZone;
 use Liberu\ControlPanel\Dns\Actions\UpdateRecord;
 use Liberu\ControlPanel\Dns\Actions\UpdateZone;
+use Liberu\ControlPanel\Dns\Actions\ValidateRecord;
 use Liberu\ControlPanel\Dns\Models\Record;
 use Liberu\ControlPanel\Dns\Models\Zone;
 use Liberu\ControlPanel\Dns\Queries\ListZones;
@@ -73,6 +74,19 @@ final class ZoneController
         $item = $create->execute(array_merge($data, ['team_id' => $teamId]));
 
         return response()->json(['data' => ['id' => $item->getKey(), 'type' => 'control-panel-dns-record', 'attributes' => $item->only(['zone_id', 'name', 'type', 'content', 'ttl', 'priority', 'metadata'])]], 201);
+    }
+
+    public function validateRecord(Request $request, ValidateRecord $validate): JsonResponse
+    {
+        $data = $request->validate([
+            'record_type' => ['required', 'in:A,AAAA,CNAME,MX,TXT,NS,PTR,SRV,CAA'],
+            'name' => ['required', 'string', 'max:253', 'regex:/^(@|[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)$/'],
+            'value' => ['required', 'string', 'max:1000'],
+            'ttl' => ['nullable', 'integer', 'between:60,86400'],
+            'priority' => ['nullable', 'integer', 'between:0,65535'],
+        ]);
+
+        return response()->json(['success' => true] + $validate->execute($data));
     }
 
     public function updateRecord(Request $request, string $id, UpdateRecord $update): JsonResponse

--- a/modules/control-panel-dns-filament/src/Resources/RecordResource.php
+++ b/modules/control-panel-dns-filament/src/Resources/RecordResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\ControlPanel\DnsFilament\Resources;
 
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
@@ -12,6 +13,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Liberu\ControlPanel\Dns\Actions\DeleteRecord;
+use Liberu\ControlPanel\Dns\Actions\ValidateRecord;
 use Liberu\ControlPanel\Dns\Models\Record;
 use Liberu\ControlPanel\DnsFilament\Resources\RecordResource\Pages\CreateRecord;
 use Liberu\ControlPanel\DnsFilament\Resources\RecordResource\Pages\EditRecord;
@@ -38,6 +40,7 @@ final class RecordResource extends Resource
     public static function table(Table $table): Table
     {
         return $table->columns([TextColumn::make('zone.domain')->label('Zone')->sortable(), TextColumn::make('name')->searchable(), TextColumn::make('type')->badge(), TextColumn::make('content')->searchable(), TextColumn::make('ttl')->sortable()])->recordActions([
+            Action::make('validate')->action(fn (Record $record): array => app(ValidateRecord::class)->execute(['type' => $record->type, 'name' => $record->name, 'content' => $record->content])),
             DeleteAction::make()->action(fn (Record $record): void => app(DeleteRecord::class)->execute($record)),
         ])->defaultSort('created_at', 'desc');
     }

--- a/modules/control-panel-dns-livewire/resources/views/components/record-inventory.blade.php
+++ b/modules/control-panel-dns-livewire/resources/views/components/record-inventory.blade.php
@@ -10,7 +10,7 @@
     </form>
     <ul>
         @forelse ($records as $record)
-            <li wire:key="dns-record-{{ $record->getKey() }}">{{ $record->name }} {{ $record->type }} {{ $record->content }} ({{ $record->zone->domain }}) <form wire:submit="update('{{ $record->getKey() }}', null)"><input aria-label="{{ __('Record content') }}" wire:model="edits.{{ $record->getKey() }}.content" value="{{ $record->content }}"><input aria-label="{{ __('Record TTL') }}" type="number" wire:model="edits.{{ $record->getKey() }}.ttl" value="{{ $record->ttl }}"><button type="submit">{{ __('Save') }}</button></form> <button type="button" wire:click="delete('{{ $record->getKey() }}')">{{ __('Delete') }}</button></li>
+            <li wire:key="dns-record-{{ $record->getKey() }}">{{ $record->name }} {{ $record->type }} {{ $record->content }} ({{ $record->zone->domain }}) <button type="button" wire:click="validateRecord('{{ $record->getKey() }}')">{{ __('Validate') }}</button> <form wire:submit="update('{{ $record->getKey() }}', null)"><input aria-label="{{ __('Record content') }}" wire:model="edits.{{ $record->getKey() }}.content" value="{{ $record->content }}"><input aria-label="{{ __('Record TTL') }}" type="number" wire:model="edits.{{ $record->getKey() }}.ttl" value="{{ $record->ttl }}"><button type="submit">{{ __('Save') }}</button></form> <button type="button" wire:click="delete('{{ $record->getKey() }}')">{{ __('Delete') }}</button></li>
         @empty
             <li>{{ __('No DNS records found.') }}</li>
         @endforelse

--- a/modules/control-panel-dns-livewire/src/Components/RecordInventory.php
+++ b/modules/control-panel-dns-livewire/src/Components/RecordInventory.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\View;
 use Liberu\ControlPanel\Dns\Actions\CreateRecord;
 use Liberu\ControlPanel\Dns\Actions\DeleteRecord;
 use Liberu\ControlPanel\Dns\Actions\UpdateRecord;
+use Liberu\ControlPanel\Dns\Actions\ValidateRecord;
 use Liberu\ControlPanel\Dns\Models\Record;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -65,6 +66,13 @@ final class RecordInventory extends Component
         $record = Record::query()->whereKey($recordId)->whereHas('zone', fn ($query) => $query->where('team_id', $this->teamId()))->firstOrFail();
         $delete->execute($record);
         unset($this->edits[$recordId]);
+    }
+
+    public function validateRecord(string $recordId, ValidateRecord $validate): void
+    {
+        $record = Record::query()->whereKey($recordId)->whereHas('zone', fn ($query) => $query->where('team_id', $this->teamId()))->firstOrFail();
+        $result = $validate->execute(['type' => $record->type, 'name' => $record->name, 'content' => $record->content]);
+        $this->dispatch('dns-record-validated', recordId: $recordId, message: $result['message']);
     }
 
     public function render(): View

--- a/modules/control-panel-dns/src/Actions/ValidateRecord.php
+++ b/modules/control-panel-dns/src/Actions/ValidateRecord.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Dns\Actions;
+
+use Illuminate\Validation\ValidationException;
+
+final class ValidateRecord
+{
+    /** @return array{valid: true, message: string} */
+    public function execute(array $attributes): array
+    {
+        $type = strtoupper(trim((string) ($attributes['record_type'] ?? $attributes['type'] ?? '')));
+        $name = trim((string) ($attributes['name'] ?? ''));
+        $value = trim((string) ($attributes['value'] ?? $attributes['content'] ?? ''));
+
+        if (! in_array($type, ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'PTR', 'SRV', 'CAA'], true)) {
+            throw ValidationException::withMessages(['record_type' => 'Unsupported DNS record type.']);
+        }
+        if (! preg_match('/^(@|[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)$/', $name)) {
+            throw ValidationException::withMessages(['name' => 'The DNS record name is invalid.']);
+        }
+        if ($value === '' || mb_strlen($value) > 1000) {
+            throw ValidationException::withMessages(['value' => 'A DNS record value is required.']);
+        }
+
+        $valid = match ($type) {
+            'A' => filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false,
+            'AAAA' => filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false,
+            'CNAME', 'MX', 'NS', 'PTR' => (bool) preg_match('/^(?=.{1,253}\\.?$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.?$/', $value),
+            'SRV' => (bool) preg_match('/^(?:[0-9]|[1-9][0-9]{1,4})\\s+(?:[0-9]|[1-9][0-9]{1,4})\\s+(?:[0-9]|[1-9][0-9]{1,4})\\s+\\S+$/', $value),
+            'CAA' => (bool) preg_match('/^(?:0|[1-9][0-9]*)\\s+[a-zA-Z0-9-]+\\s+".*"$/', $value),
+            'TXT' => true,
+        };
+
+        if (! $valid) {
+            throw ValidationException::withMessages(['value' => "The value is invalid for {$type} records."]);
+        }
+
+        return ['valid' => true, 'message' => 'DNS record is valid.'];
+    }
+}

--- a/modules/control-panel-dns/src/DnsServiceProvider.php
+++ b/modules/control-panel-dns/src/DnsServiceProvider.php
@@ -11,6 +11,7 @@ use Liberu\ControlPanel\Dns\Actions\DeleteRecord;
 use Liberu\ControlPanel\Dns\Actions\RecordDnsCheck;
 use Liberu\ControlPanel\Dns\Actions\RegisterDnsFeature;
 use Liberu\ControlPanel\Dns\Actions\SuspendZone;
+use Liberu\ControlPanel\Dns\Actions\ValidateRecord;
 
 final class DnsServiceProvider extends ServiceProvider
 {
@@ -22,6 +23,7 @@ final class DnsServiceProvider extends ServiceProvider
         $this->app->scoped(RecordDnsCheck::class);
         $this->app->scoped(RegisterDnsFeature::class);
         $this->app->scoped(SuspendZone::class);
+        $this->app->scoped(ValidateRecord::class);
     }
 
     public function boot(): void

--- a/modules/control-panel-mail-api/openapi/v1/control-panel-mail.yaml
+++ b/modules/control-panel-mail-api/openapi/v1/control-panel-mail.yaml
@@ -8,6 +8,9 @@ paths:
     post: {operationId: control.panel.mail.operations.create, security: [{sanctum: []}], responses: {'201': {$ref: '#/components/responses/Resource'}}}
   /api/v1/control-panel/mail/aliases:
     post: {operationId: control.panel.mail.aliases.create, security: [{sanctum: []}], responses: {'201': {$ref: '#/components/responses/Resource'}}}
+  /api/v1/control-panel/mail/aliases/{alias}:
+    patch: {operationId: control.panel.mail.aliases.update, security: [{sanctum: []}], responses: {'200': {$ref: '#/components/responses/Resource'}}}
+    delete: {operationId: control.panel.mail.aliases.delete, security: [{sanctum: []}], responses: {'204': {description: Mail alias deleted.}}}
   /api/v1/control-panel/mail/routes:
     post: {operationId: control.panel.mail.routes.create, security: [{sanctum: []}], responses: {'201': {$ref: '#/components/responses/Resource'}}}
   /api/v1/control-panel/mail/controls:

--- a/modules/control-panel-mail-api/openapi/v1/control-panel-mail.yaml
+++ b/modules/control-panel-mail-api/openapi/v1/control-panel-mail.yaml
@@ -13,6 +13,9 @@ paths:
     delete: {operationId: control.panel.mail.aliases.delete, security: [{sanctum: []}], responses: {'204': {description: Mail alias deleted.}}}
   /api/v1/control-panel/mail/routes:
     post: {operationId: control.panel.mail.routes.create, security: [{sanctum: []}], responses: {'201': {$ref: '#/components/responses/Resource'}}}
+  /api/v1/control-panel/mail/routes/{route}:
+    patch: {operationId: control.panel.mail.routes.update, security: [{sanctum: []}], responses: {'200': {$ref: '#/components/responses/Resource'}}}
+    delete: {operationId: control.panel.mail.routes.delete, security: [{sanctum: []}], responses: {'204': {description: Mail route deleted.}}}
   /api/v1/control-panel/mail/controls:
     post: {operationId: control.panel.mail.controls.configure, security: [{sanctum: []}], responses: {'201': {$ref: '#/components/responses/Resource'}}}
   /api/v1/control-panel/mail/delivery-diagnostics:

--- a/modules/control-panel-mail-api/routes/api.php
+++ b/modules/control-panel-mail-api/routes/api.php
@@ -13,6 +13,8 @@ Route::prefix('api/v1/control-panel/mail')->middleware(['api', 'auth:sanctum', '
     Route::patch('/aliases/{alias}', [MailAccountController::class, 'updateAlias'])->name('control-panel.mail.aliases.update');
     Route::delete('/aliases/{alias}', [MailAccountController::class, 'deleteAlias'])->name('control-panel.mail.aliases.delete');
     Route::post('/routes', [MailAccountController::class, 'route'])->name('control-panel.mail.routes.store');
+    Route::patch('/routes/{route}', [MailAccountController::class, 'updateRoute'])->name('control-panel.mail.routes.update');
+    Route::delete('/routes/{route}', [MailAccountController::class, 'deleteRoute'])->name('control-panel.mail.routes.delete');
     Route::post('/controls', [MailAccountController::class, 'controls'])->name('control-panel.mail.controls.store');
     Route::post('/delivery-diagnostics', [MailAccountController::class, 'diagnostic'])->name('control-panel.mail.delivery-diagnostics.store');
     Route::post('/dkim/rotate', [MailAccountController::class, 'rotateDkim'])->name('control-panel.mail.dkim.rotate');

--- a/modules/control-panel-mail-api/routes/api.php
+++ b/modules/control-panel-mail-api/routes/api.php
@@ -8,14 +8,16 @@ use Liberu\ControlPanel\MailApi\Http\Controllers\MailAccountController;
 Route::prefix('api/v1/control-panel/mail')->middleware(['api', 'auth:sanctum', 'throttle:60,1'])->group(function (): void {
     Route::get('/', [MailAccountController::class, 'index'])->name('control-panel.mail.index');
     Route::post('/', [MailAccountController::class, 'store'])->name('control-panel.mail.store');
-    Route::patch('/{mailAccount}', [MailAccountController::class, 'update'])->name('control-panel.mail.update');
-    Route::delete('/{mailAccount}', [MailAccountController::class, 'delete'])->name('control-panel.mail.delete');
     Route::post('/operations', [MailAccountController::class, 'operation'])->name('control-panel.mail.operations.store');
     Route::post('/aliases', [MailAccountController::class, 'alias'])->name('control-panel.mail.aliases.store');
+    Route::patch('/aliases/{alias}', [MailAccountController::class, 'updateAlias'])->name('control-panel.mail.aliases.update');
+    Route::delete('/aliases/{alias}', [MailAccountController::class, 'deleteAlias'])->name('control-panel.mail.aliases.delete');
     Route::post('/routes', [MailAccountController::class, 'route'])->name('control-panel.mail.routes.store');
     Route::post('/controls', [MailAccountController::class, 'controls'])->name('control-panel.mail.controls.store');
     Route::post('/delivery-diagnostics', [MailAccountController::class, 'diagnostic'])->name('control-panel.mail.delivery-diagnostics.store');
     Route::post('/dkim/rotate', [MailAccountController::class, 'rotateDkim'])->name('control-panel.mail.dkim.rotate');
     Route::post('/domains', [MailAccountController::class, 'domain'])->name('control-panel.mail.domains.store');
+    Route::patch('/{mailAccount}', [MailAccountController::class, 'update'])->name('control-panel.mail.update');
+    Route::delete('/{mailAccount}', [MailAccountController::class, 'delete'])->name('control-panel.mail.delete');
     Route::get('/{mailAccount}', [MailAccountController::class, 'show'])->name('control-panel.mail.show');
 });

--- a/modules/control-panel-mail-api/src/Http/Controllers/MailAccountController.php
+++ b/modules/control-panel-mail-api/src/Http/Controllers/MailAccountController.php
@@ -11,12 +11,15 @@ use Liberu\ControlPanel\Mail\Actions\CreateMailAccount;
 use Liberu\ControlPanel\Mail\Actions\CreateMailAlias;
 use Liberu\ControlPanel\Mail\Actions\CreateMailRoute;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAccount;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
 use Liberu\ControlPanel\Mail\Actions\RecordDeliveryDiagnostic;
 use Liberu\ControlPanel\Mail\Actions\RecordMailOperation;
 use Liberu\ControlPanel\Mail\Actions\RegisterMailDomain;
 use Liberu\ControlPanel\Mail\Actions\RotateDkimKey;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAccount;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
 use Liberu\ControlPanel\Mail\Models\MailAccount;
+use Liberu\ControlPanel\Mail\Models\MailAlias;
 use Liberu\ControlPanel\Mail\Models\MailDomain;
 use Liberu\ControlPanel\Mail\Models\MailRoute;
 use Liberu\ControlPanel\Mail\Queries\ListMailAccounts;
@@ -93,6 +96,28 @@ final class MailAccountController
         $item = $create->execute(array_merge($data, ['team_id' => $teamId]));
 
         return response()->json(['data' => ['id' => $item->getKey(), 'type' => 'control-panel-mail-alias', 'attributes' => $item->only(['domain', 'address', 'destinations', 'active'])]], 201);
+    }
+
+    public function updateAlias(Request $request, string $id, UpdateMailAlias $update): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $alias = MailAlias::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
+        $data = $request->validate(['domain' => ['sometimes', 'string', 'max:253'], 'address' => ['sometimes', 'string', 'max:320'], 'destinations' => ['sometimes', 'array', 'min:1'], 'destinations.*' => ['email'], 'active' => ['sometimes', 'boolean']]);
+
+        $item = $update->execute($alias, $data);
+
+        return response()->json(['data' => ['id' => $item->getKey(), 'type' => 'control-panel-mail-alias', 'attributes' => $item->only(['domain', 'address', 'destinations', 'active'])]]);
+    }
+
+    public function deleteAlias(Request $request, string $id, DeleteMailAlias $delete): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $alias = MailAlias::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
+        $delete->execute($alias);
+
+        return response()->json(status: 204);
     }
 
     public function route(Request $request, CreateMailRoute $create): JsonResponse

--- a/modules/control-panel-mail-api/src/Http/Controllers/MailAccountController.php
+++ b/modules/control-panel-mail-api/src/Http/Controllers/MailAccountController.php
@@ -12,12 +12,14 @@ use Liberu\ControlPanel\Mail\Actions\CreateMailAlias;
 use Liberu\ControlPanel\Mail\Actions\CreateMailRoute;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAccount;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailRoute;
 use Liberu\ControlPanel\Mail\Actions\RecordDeliveryDiagnostic;
 use Liberu\ControlPanel\Mail\Actions\RecordMailOperation;
 use Liberu\ControlPanel\Mail\Actions\RegisterMailDomain;
 use Liberu\ControlPanel\Mail\Actions\RotateDkimKey;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAccount;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailRoute;
 use Liberu\ControlPanel\Mail\Models\MailAccount;
 use Liberu\ControlPanel\Mail\Models\MailAlias;
 use Liberu\ControlPanel\Mail\Models\MailDomain;
@@ -116,6 +118,26 @@ final class MailAccountController
         abort_if($teamId === null, 403, 'A current team is required.');
         $alias = MailAlias::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
         $delete->execute($alias);
+
+        return response()->json(status: 204);
+    }
+
+    public function updateRoute(Request $request, string $id, UpdateMailRoute $update): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $route = MailRoute::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
+        $data = $request->validate(['domain' => ['sometimes', 'string', 'max:253'], 'source_pattern' => ['sometimes', 'string', 'max:255'], 'destination' => ['sometimes', 'email', 'max:320'], 'priority' => ['sometimes', 'integer', 'min:0'], 'active' => ['sometimes', 'boolean']]);
+
+        return response()->json(['data' => self::routeResource($update->execute($route, $data))]);
+    }
+
+    public function deleteRoute(Request $request, string $id, DeleteMailRoute $delete): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $route = MailRoute::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
+        $delete->execute($route);
 
         return response()->json(status: 204);
     }

--- a/modules/control-panel-mail-filament/src/Resources/MailAliasResource.php
+++ b/modules/control-panel-mail-filament/src/Resources/MailAliasResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\ControlPanel\MailFilament\Resources;
 
+use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
@@ -12,6 +13,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
 use Liberu\ControlPanel\Mail\Models\MailAlias;
 use Liberu\ControlPanel\MailFilament\Resources\MailAliasResource\Pages\CreateMailAlias;
 use Liberu\ControlPanel\MailFilament\Resources\MailAliasResource\Pages\EditMailAlias;
@@ -37,7 +39,13 @@ final class MailAliasResource extends Resource
 
     public static function table(Table $table): Table
     {
-        return $table->columns([TextColumn::make('domain'), TextColumn::make('address')->searchable(), TextColumn::make('destinations')->listWithLineBreaks(), TextColumn::make('active')->badge()]);
+        return $table->columns([TextColumn::make('domain'), TextColumn::make('address')->searchable(), TextColumn::make('destinations')->listWithLineBreaks(), TextColumn::make('active')->badge()])->recordActions([
+            DeleteAction::make()->action(function (MailAlias $record): void {
+                abort_if(auth()->user()?->current_team_id === null, 403, 'A current team is required.');
+                abort_unless((string) $record->team_id === (string) auth()->user()?->current_team_id, 404);
+                app(DeleteMailAlias::class)->execute($record);
+            }),
+        ]);
     }
 
     public static function getEloquentQuery(): Builder

--- a/modules/control-panel-mail-filament/src/Resources/MailAliasResource/Pages/EditMailAlias.php
+++ b/modules/control-panel-mail-filament/src/Resources/MailAliasResource/Pages/EditMailAlias.php
@@ -5,9 +5,21 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\MailFilament\Resources\MailAliasResource\Pages;
 
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
+use Liberu\ControlPanel\Mail\Models\MailAlias;
 use Liberu\ControlPanel\MailFilament\Resources\MailAliasResource;
 
 final class EditMailAlias extends EditRecord
 {
     protected static string $resource = MailAliasResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var MailAlias $record */
+        abort_if(auth()->user()?->current_team_id === null, 403, 'A current team is required.');
+        abort_unless((string) $record->team_id === (string) auth()->user()?->current_team_id, 404);
+
+        return app(UpdateMailAlias::class)->execute($record, $data);
+    }
 }

--- a/modules/control-panel-mail-filament/src/Resources/MailRouteResource.php
+++ b/modules/control-panel-mail-filament/src/Resources/MailRouteResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\ControlPanel\MailFilament\Resources;
 
+use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Resource;
@@ -11,6 +12,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailRoute;
 use Liberu\ControlPanel\Mail\Models\MailRoute;
 use Liberu\ControlPanel\MailFilament\Resources\MailRouteResource\Pages\CreateMailRoute;
 use Liberu\ControlPanel\MailFilament\Resources\MailRouteResource\Pages\EditMailRoute;
@@ -37,7 +39,13 @@ final class MailRouteResource extends Resource
 
     public static function table(Table $table): Table
     {
-        return $table->columns([TextColumn::make('domain')->searchable(), TextColumn::make('source_pattern'), TextColumn::make('destination')->searchable(), TextColumn::make('priority')->sortable(), TextColumn::make('active')->badge()]);
+        return $table->columns([TextColumn::make('domain')->searchable(), TextColumn::make('source_pattern'), TextColumn::make('destination')->searchable(), TextColumn::make('priority')->sortable(), TextColumn::make('active')->badge()])->recordActions([
+            DeleteAction::make()->action(function (MailRoute $record): void {
+                abort_if(auth()->user()?->current_team_id === null, 403, 'A current team is required.');
+                abort_unless((string) $record->team_id === (string) auth()->user()?->current_team_id, 404);
+                app(DeleteMailRoute::class)->execute($record);
+            }),
+        ]);
     }
 
     public static function getEloquentQuery(): Builder

--- a/modules/control-panel-mail-filament/src/Resources/MailRouteResource/Pages/EditMailRoute.php
+++ b/modules/control-panel-mail-filament/src/Resources/MailRouteResource/Pages/EditMailRoute.php
@@ -5,9 +5,21 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\MailFilament\Resources\MailRouteResource\Pages;
 
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailRoute;
+use Liberu\ControlPanel\Mail\Models\MailRoute;
 use Liberu\ControlPanel\MailFilament\Resources\MailRouteResource;
 
 final class EditMailRoute extends EditRecord
 {
     protected static string $resource = MailRouteResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var MailRoute $record */
+        abort_if(auth()->user()?->current_team_id === null, 403, 'A current team is required.');
+        abort_unless((string) $record->team_id === (string) auth()->user()?->current_team_id, 404);
+
+        return app(UpdateMailRoute::class)->execute($record, $data);
+    }
 }

--- a/modules/control-panel-mail-livewire/resources/views/components/mail-feature-inventory.blade.php
+++ b/modules/control-panel-mail-livewire/resources/views/components/mail-feature-inventory.blade.php
@@ -16,7 +16,7 @@
         @endforelse
     </ul>
     <h2>{{ __('Mail aliases and delivery diagnostics') }}</h2>
-    <ul>@forelse ($aliases as $alias)<li wire:key="alias-{{ $alias->getKey() }}">{{ $alias->address }}@{{ $alias->domain }}</li>@empty<li>{{ __('No aliases found.') }}</li>@endforelse</ul>
+    <ul>@forelse ($aliases as $alias)<li wire:key="alias-{{ $alias->getKey() }}">{{ $alias->address }}@{{ $alias->domain }} <form wire:submit="updateAlias('{{ $alias->getKey() }}', null)"><input aria-label="{{ __('Alias domain') }}" wire:model="aliasEdits.{{ $alias->getKey() }}.domain" value="{{ $alias->domain }}"><input aria-label="{{ __('Alias address') }}" wire:model="aliasEdits.{{ $alias->getKey() }}.address" value="{{ $alias->address }}"><button type="submit">{{ __('Save') }}</button></form> <button type="button" wire:click="deleteAlias('{{ $alias->getKey() }}')">{{ __('Delete') }}</button></li>@empty<li>{{ __('No aliases found.') }}</li>@endforelse</ul>
     {{ $aliases->links() }}
     <h3>{{ __('Recent diagnostics') }}</h3><ul>@forelse ($diagnostics as $diagnostic)<li wire:key="diagnostic-{{ $diagnostic->getKey() }}">{{ $diagnostic->recipient }} — {{ $diagnostic->status }}</li>@empty<li>{{ __('No diagnostics found.') }}</li>@endforelse</ul>
     <h3>{{ __('DKIM keys') }}</h3>

--- a/modules/control-panel-mail-livewire/resources/views/components/mail-feature-inventory.blade.php
+++ b/modules/control-panel-mail-livewire/resources/views/components/mail-feature-inventory.blade.php
@@ -10,7 +10,7 @@
     <h2>{{ __('Mail routes') }}</h2>
     <ul>
         @forelse ($routes as $route)
-            <li wire:key="route-{{ $route->getKey() }}">{{ $route->domain }} — {{ $route->source_pattern }} → {{ $route->destination }}</li>
+            <li wire:key="route-{{ $route->getKey() }}">{{ $route->domain }} — <form wire:submit="updateRoute('{{ $route->getKey() }}', null)" class="inline"><input aria-label="{{ __('Route source pattern') }}" wire:model="routeEdits.{{ $route->getKey() }}.source_pattern" value="{{ $route->source_pattern }}"><input aria-label="{{ __('Route destination') }}" wire:model="routeEdits.{{ $route->getKey() }}.destination" value="{{ $route->destination }}"><button type="submit">{{ __('Save') }}</button></form> <button type="button" wire:click="deleteRoute('{{ $route->getKey() }}')">{{ __('Delete') }}</button></li>
         @empty
             <li>{{ __('No mail routes found.') }}</li>
         @endforelse

--- a/modules/control-panel-mail-livewire/src/Components/MailFeatureInventory.php
+++ b/modules/control-panel-mail-livewire/src/Components/MailFeatureInventory.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\MailLivewire\Components;
 
 use Illuminate\Contracts\View\View;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
 use Liberu\ControlPanel\Mail\Actions\RotateDkimKey;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
 use Liberu\ControlPanel\Mail\Models\DeliveryDiagnostic;
 use Liberu\ControlPanel\Mail\Models\DkimKey;
 use Liberu\ControlPanel\Mail\Models\MailAlias;
@@ -17,9 +19,29 @@ final class MailFeatureInventory extends Component
 {
     public int $perPage = 25;
 
+    /** @var array<string, array<string, mixed>> */
+    public array $aliasEdits = [];
+
     public function rotateDkim(string $domain, RotateDkimKey $rotate): void
     {
         $rotate->execute($this->teamId(), $domain);
+    }
+
+    /** @param array<string, mixed>|null $attributes */
+    public function updateAlias(string $aliasId, ?array $attributes, UpdateMailAlias $update): void
+    {
+        $alias = MailAlias::query()->whereKey($aliasId)->where('team_id', $this->teamId())->firstOrFail();
+        $attributes ??= $this->aliasEdits[$aliasId] ?? [];
+        validator($attributes, ['domain' => ['required', 'string', 'max:253'], 'address' => ['required', 'string', 'max:320'], 'destinations' => ['required', 'array', 'min:1'], 'destinations.*' => ['email'], 'active' => ['sometimes', 'boolean']])->validate();
+        $update->execute($alias, $attributes);
+        unset($this->aliasEdits[$aliasId]);
+    }
+
+    public function deleteAlias(string $aliasId, DeleteMailAlias $delete): void
+    {
+        $alias = MailAlias::query()->whereKey($aliasId)->where('team_id', $this->teamId())->firstOrFail();
+        $delete->execute($alias);
+        unset($this->aliasEdits[$aliasId]);
     }
 
     public function render(): View

--- a/modules/control-panel-mail-livewire/src/Components/MailFeatureInventory.php
+++ b/modules/control-panel-mail-livewire/src/Components/MailFeatureInventory.php
@@ -6,8 +6,10 @@ namespace Liberu\ControlPanel\MailLivewire\Components;
 
 use Illuminate\Contracts\View\View;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailRoute;
 use Liberu\ControlPanel\Mail\Actions\RotateDkimKey;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailRoute;
 use Liberu\ControlPanel\Mail\Models\DeliveryDiagnostic;
 use Liberu\ControlPanel\Mail\Models\DkimKey;
 use Liberu\ControlPanel\Mail\Models\MailAlias;
@@ -21,6 +23,9 @@ final class MailFeatureInventory extends Component
 
     /** @var array<string, array<string, mixed>> */
     public array $aliasEdits = [];
+
+    /** @var array<string, array<string, mixed>> */
+    public array $routeEdits = [];
 
     public function rotateDkim(string $domain, RotateDkimKey $rotate): void
     {
@@ -42,6 +47,23 @@ final class MailFeatureInventory extends Component
         $alias = MailAlias::query()->whereKey($aliasId)->where('team_id', $this->teamId())->firstOrFail();
         $delete->execute($alias);
         unset($this->aliasEdits[$aliasId]);
+    }
+
+    /** @param array<string, mixed>|null $attributes */
+    public function updateRoute(string $routeId, ?array $attributes, UpdateMailRoute $update): void
+    {
+        $route = MailRoute::query()->whereKey($routeId)->where('team_id', $this->teamId())->firstOrFail();
+        $attributes ??= $this->routeEdits[$routeId] ?? [];
+        validator($attributes, ['domain' => ['required', 'string', 'max:253'], 'source_pattern' => ['required', 'string', 'max:255'], 'destination' => ['required', 'email', 'max:320'], 'priority' => ['required', 'integer', 'min:0'], 'active' => ['sometimes', 'boolean']])->validate();
+        $update->execute($route, $attributes);
+        unset($this->routeEdits[$routeId]);
+    }
+
+    public function deleteRoute(string $routeId, DeleteMailRoute $delete): void
+    {
+        $route = MailRoute::query()->whereKey($routeId)->where('team_id', $this->teamId())->firstOrFail();
+        $delete->execute($route);
+        unset($this->routeEdits[$routeId]);
     }
 
     public function render(): View

--- a/modules/control-panel-mail/src/Actions/DeleteMailAlias.php
+++ b/modules/control-panel-mail/src/Actions/DeleteMailAlias.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Mail\Actions;
+
+use Liberu\ControlPanel\Mail\Models\MailAlias;
+
+final class DeleteMailAlias
+{
+    public function execute(MailAlias $alias): void
+    {
+        $alias->delete();
+    }
+}

--- a/modules/control-panel-mail/src/Actions/DeleteMailRoute.php
+++ b/modules/control-panel-mail/src/Actions/DeleteMailRoute.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Mail\Actions;
+
+use Liberu\ControlPanel\Mail\Models\MailRoute;
+
+final class DeleteMailRoute
+{
+    public function execute(MailRoute $route): void
+    {
+        $route->delete();
+    }
+}

--- a/modules/control-panel-mail/src/Actions/UpdateMailAlias.php
+++ b/modules/control-panel-mail/src/Actions/UpdateMailAlias.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Mail\Actions;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\Mail\Models\MailAlias;
+
+final class UpdateMailAlias
+{
+    public function execute(MailAlias $alias, array $attributes): MailAlias
+    {
+        $domain = trim((string) ($attributes['domain'] ?? $alias->domain));
+        $address = trim((string) ($attributes['address'] ?? $alias->address));
+        $destinations = array_values(array_filter(array_map('trim', $attributes['destinations'] ?? $alias->destinations ?? [])));
+        if (! filter_var($address.'@'.$domain, FILTER_VALIDATE_EMAIL) || $destinations === [] || array_filter($destinations, fn (string $destination): bool => filter_var($destination, FILTER_VALIDATE_EMAIL) === false) !== []) {
+            throw ValidationException::withMessages(['alias' => 'A valid alias and at least one destination are required.']);
+        }
+
+        $alias->forceFill(['domain' => $domain, 'address' => $address, 'destinations' => $destinations, 'active' => $attributes['active'] ?? $alias->active])->save();
+
+        return $alias->refresh();
+    }
+}

--- a/modules/control-panel-mail/src/Actions/UpdateMailRoute.php
+++ b/modules/control-panel-mail/src/Actions/UpdateMailRoute.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Mail\Actions;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\Mail\Models\MailRoute;
+
+final class UpdateMailRoute
+{
+    /** @param array<string, mixed> $attributes */
+    public function execute(MailRoute $route, array $attributes): MailRoute
+    {
+        $domain = strtolower(trim((string) ($attributes['domain'] ?? $route->domain)));
+        $sourcePattern = trim((string) ($attributes['source_pattern'] ?? $route->source_pattern));
+        $destination = trim((string) ($attributes['destination'] ?? $route->destination));
+        $priority = (int) ($attributes['priority'] ?? $route->priority);
+
+        if ($domain === '' || mb_strlen($domain) > 253 || ! filter_var($domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) || $sourcePattern === '' || ! filter_var($destination, FILTER_VALIDATE_EMAIL) || $priority < 0) {
+            throw ValidationException::withMessages(['route' => 'A valid domain, source pattern, destination, and priority are required.']);
+        }
+
+        $route->forceFill(['domain' => $domain, 'source_pattern' => $sourcePattern, 'destination' => $destination, 'priority' => $priority, 'active' => $attributes['active'] ?? $route->active])->save();
+
+        return $route->refresh();
+    }
+}

--- a/modules/control-panel-mail/src/MailServiceProvider.php
+++ b/modules/control-panel-mail/src/MailServiceProvider.php
@@ -10,10 +10,12 @@ use Liberu\ControlPanel\Mail\Actions\CreateMailAccount;
 use Liberu\ControlPanel\Mail\Actions\CreateMailAlias;
 use Liberu\ControlPanel\Mail\Actions\CreateMailRoute;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAccount;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
 use Liberu\ControlPanel\Mail\Actions\RecordDeliveryDiagnostic;
 use Liberu\ControlPanel\Mail\Actions\RecordMailOperation;
 use Liberu\ControlPanel\Mail\Actions\RegisterMailDomain;
 use Liberu\ControlPanel\Mail\Actions\RotateDkimKey;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
 use Liberu\ControlPanel\Mail\Queries\ListMailAccounts;
 
 final class MailServiceProvider extends ServiceProvider
@@ -23,6 +25,8 @@ final class MailServiceProvider extends ServiceProvider
         $this->app->scoped(CreateMailAccount::class);
         $this->app->scoped(DeleteMailAccount::class);
         $this->app->scoped(CreateMailAlias::class);
+        $this->app->scoped(DeleteMailAlias::class);
+        $this->app->scoped(UpdateMailAlias::class);
         $this->app->scoped(CreateMailRoute::class);
         $this->app->scoped(ConfigureMailControls::class);
         $this->app->scoped(RecordDeliveryDiagnostic::class);

--- a/modules/control-panel-mail/src/MailServiceProvider.php
+++ b/modules/control-panel-mail/src/MailServiceProvider.php
@@ -11,11 +11,13 @@ use Liberu\ControlPanel\Mail\Actions\CreateMailAlias;
 use Liberu\ControlPanel\Mail\Actions\CreateMailRoute;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAccount;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailRoute;
 use Liberu\ControlPanel\Mail\Actions\RecordDeliveryDiagnostic;
 use Liberu\ControlPanel\Mail\Actions\RecordMailOperation;
 use Liberu\ControlPanel\Mail\Actions\RegisterMailDomain;
 use Liberu\ControlPanel\Mail\Actions\RotateDkimKey;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailRoute;
 use Liberu\ControlPanel\Mail\Queries\ListMailAccounts;
 
 final class MailServiceProvider extends ServiceProvider
@@ -28,6 +30,8 @@ final class MailServiceProvider extends ServiceProvider
         $this->app->scoped(DeleteMailAlias::class);
         $this->app->scoped(UpdateMailAlias::class);
         $this->app->scoped(CreateMailRoute::class);
+        $this->app->scoped(DeleteMailRoute::class);
+        $this->app->scoped(UpdateMailRoute::class);
         $this->app->scoped(ConfigureMailControls::class);
         $this->app->scoped(RecordDeliveryDiagnostic::class);
         $this->app->scoped(ListMailAccounts::class);

--- a/modules/control-panel-mail/src/Models/MailAlias.php
+++ b/modules/control-panel-mail/src/Models/MailAlias.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\ControlPanel\Mail\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 
 final class MailAlias extends Model
 {
+    use HasUuids;
+
     protected $table = 'control_panel_mail_aliases';
 
     protected $fillable = ['id', 'team_id', 'domain', 'address', 'destinations', 'active'];

--- a/modules/control-panel-mail/src/Models/MailRoute.php
+++ b/modules/control-panel-mail/src/Models/MailRoute.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\ControlPanel\Mail\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 
 final class MailRoute extends Model
 {
+    use HasUuids;
+
     protected $table = 'control_panel_mail_routes';
 
     protected $fillable = ['id', 'team_id', 'domain', 'source_pattern', 'destination', 'priority', 'active'];

--- a/tests/Feature/ControlPanelDnsTest.php
+++ b/tests/Feature/ControlPanelDnsTest.php
@@ -11,6 +11,7 @@ use Liberu\ControlPanel\Dns\Actions\CreateZone;
 use Liberu\ControlPanel\Dns\Actions\DeleteRecord;
 use Liberu\ControlPanel\Dns\Actions\UpdateRecord;
 use Liberu\ControlPanel\Dns\Actions\UpdateZone;
+use Liberu\ControlPanel\Dns\Actions\ValidateRecord;
 use Liberu\ControlPanel\Dns\DnsServiceProvider;
 use Liberu\ControlPanel\Dns\Enums\ZoneStatus;
 use Liberu\ControlPanel\Dns\Events\ZoneCreated;
@@ -68,4 +69,10 @@ it('deletes a DNS record through the domain action', function (): void {
     app(DeleteRecord::class)->execute($record);
 
     expect($zone->records()->whereKey($record->getKey())->exists())->toBeFalse();
+});
+
+it('validates DNS record values by type', function (): void {
+    expect(app(ValidateRecord::class)->execute(['record_type' => 'A', 'name' => '@', 'value' => '192.0.2.1']))->toMatchArray(['valid' => true]);
+    expect(fn () => app(ValidateRecord::class)->execute(['record_type' => 'A', 'name' => '@', 'value' => 'not-an-ip']))->toThrow(ValidationException::class);
+    expect(fn () => app(ValidateRecord::class)->execute(['record_type' => 'SRV', 'name' => '_http', 'value' => '0 5 443 service.example.com']))->toThrow(ValidationException::class);
 });

--- a/tests/Feature/DnsApiLifecycleTest.php
+++ b/tests/Feature/DnsApiLifecycleTest.php
@@ -103,3 +103,18 @@ it('bulk creates tenant DNS records with bounded partial results', function (): 
     $response->assertCreated()->assertJsonCount(2, 'data');
     expect($zone->records()->count())->toBe(2);
 });
+
+it('validates DNS record content through the API', function (): void {
+    $team = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/control-panel/dns/records/validate', ['record_type' => 'A', 'name' => '@', 'value' => '192.0.2.10'])
+        ->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('valid', true);
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/control-panel/dns/records/validate', ['record_type' => 'A', 'name' => '@', 'value' => 'invalid'])
+        ->assertUnprocessable();
+});

--- a/tests/Feature/MailAccountUpdateApiLivewireTest.php
+++ b/tests/Feature/MailAccountUpdateApiLivewireTest.php
@@ -6,11 +6,16 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\ControlPanel\Mail\Actions\CreateMailAccount;
+use Liberu\ControlPanel\Mail\Actions\CreateMailAlias;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAccount;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAccount;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
 use Liberu\ControlPanel\Mail\MailServiceProvider;
 use Liberu\ControlPanel\Mail\Models\MailAccount;
+use Liberu\ControlPanel\Mail\Models\MailAlias;
 use Liberu\ControlPanel\MailApi\MailApiServiceProvider;
+use Liberu\ControlPanel\MailLivewire\Components\MailFeatureInventory;
 use Liberu\ControlPanel\MailLivewire\Components\MailInventory;
 use Liberu\ControlPanel\MailLivewire\MailLivewireServiceProvider;
 use Liberu\Foundation\Organizations\Models\Team;
@@ -67,6 +72,60 @@ it('deletes only a current-team mailbox through API and Livewire', function (): 
 
     expect(MailAccount::query()->whereKey($owned->getKey())->exists())->toBeFalse()
         ->and(MailAccount::query()->whereKey($livewireAccount->getKey())->exists())->toBeFalse();
+});
+
+it('updates and deletes only a current-team alias through API and Livewire', function (): void {
+    $team = Team::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $foreign = app(CreateMailAlias::class)->execute([
+        'team_id' => $otherTeam->getKey(),
+        'domain' => 'other-alias.test',
+        'address' => 'support',
+        'destinations' => ['other@example.test'],
+    ]);
+    $owned = app(CreateMailAlias::class)->execute([
+        'team_id' => $team->getKey(),
+        'domain' => 'owned-alias.test',
+        'address' => 'support',
+        'destinations' => ['ops@example.test'],
+    ]);
+
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/mail/aliases/'.$foreign->getKey(), [
+        'domain' => 'blocked.test',
+        'address' => 'blocked',
+        'destinations' => ['blocked@example.test'],
+    ])->assertNotFound();
+
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/mail/aliases/'.$owned->getKey(), [
+        'domain' => 'updated-alias.test',
+        'address' => 'helpdesk',
+        'destinations' => ['team@example.test'],
+        'active' => false,
+    ])->assertOk()->assertJsonPath('data.attributes.domain', 'updated-alias.test');
+
+    $inventory = app(MailFeatureInventory::class);
+    $this->actingAs($user);
+
+    expect(fn () => $inventory->updateAlias($foreign->getKey(), [
+        'domain' => 'blocked.test',
+        'address' => 'blocked',
+        'destinations' => ['blocked@example.test'],
+    ], app(UpdateMailAlias::class)))->toThrow(ModelNotFoundException::class);
+
+    $livewireAlias = app(CreateMailAlias::class)->execute([
+        'team_id' => $team->getKey(),
+        'domain' => 'livewire-alias.test',
+        'address' => 'support',
+        'destinations' => ['ops@example.test'],
+    ]);
+    $inventory->deleteAlias($livewireAlias->getKey(), app(DeleteMailAlias::class));
+
+    $this->actingAs($user, 'sanctum')->deleteJson('/api/v1/control-panel/mail/aliases/'.$foreign->getKey())->assertNotFound();
+    $this->actingAs($user, 'sanctum')->deleteJson('/api/v1/control-panel/mail/aliases/'.$owned->getKey())->assertNoContent();
+
+    expect(MailAlias::query()->whereKey($owned->getKey())->exists())->toBeFalse()
+        ->and(MailAlias::query()->whereKey($livewireAlias->getKey())->exists())->toBeFalse();
 });
 
 it('rejects mail operations targeting another team account', function (): void {

--- a/tests/Feature/MailAccountUpdateApiLivewireTest.php
+++ b/tests/Feature/MailAccountUpdateApiLivewireTest.php
@@ -7,13 +7,17 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\ControlPanel\Mail\Actions\CreateMailAccount;
 use Liberu\ControlPanel\Mail\Actions\CreateMailAlias;
+use Liberu\ControlPanel\Mail\Actions\CreateMailRoute;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAccount;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailRoute;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAccount;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailRoute;
 use Liberu\ControlPanel\Mail\MailServiceProvider;
 use Liberu\ControlPanel\Mail\Models\MailAccount;
 use Liberu\ControlPanel\Mail\Models\MailAlias;
+use Liberu\ControlPanel\Mail\Models\MailRoute;
 use Liberu\ControlPanel\MailApi\MailApiServiceProvider;
 use Liberu\ControlPanel\MailLivewire\Components\MailFeatureInventory;
 use Liberu\ControlPanel\MailLivewire\Components\MailInventory;
@@ -136,4 +140,28 @@ it('rejects mail operations targeting another team account', function (): void {
 
     $this->actingAs($user, 'sanctum')->postJson('/api/v1/control-panel/mail/operations', ['mail_account_id' => $foreign->getKey(), 'operation' => 'deliver'])->assertNotFound();
     $this->actingAs($user, 'sanctum')->postJson('/api/v1/control-panel/mail/controls', ['mail_account_id' => $foreign->getKey(), 'spam_threshold' => 5])->assertNotFound();
+});
+
+it('updates and deletes only a current-team route through API and Livewire', function (): void {
+    $team = Team::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $foreign = app(CreateMailRoute::class)->execute(['team_id' => $otherTeam->getKey(), 'domain' => 'other-route.test', 'source_pattern' => 'support', 'destination' => 'other@example.test']);
+    $owned = app(CreateMailRoute::class)->execute(['team_id' => $team->getKey(), 'domain' => 'owned-route.test', 'source_pattern' => 'support', 'destination' => 'ops@example.test']);
+
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/mail/routes/'.$foreign->getKey(), ['destination' => 'blocked@example.test'])->assertNotFound();
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/mail/routes/'.$owned->getKey(), ['source_pattern' => 'helpdesk', 'destination' => 'team@example.test', 'priority' => 10])->assertOk()->assertJsonPath('data.attributes.source_pattern', 'helpdesk');
+
+    $inventory = app(MailFeatureInventory::class);
+    $this->actingAs($user);
+    expect(fn () => $inventory->updateRoute($foreign->getKey(), ['domain' => 'other-route.test', 'source_pattern' => 'support', 'destination' => 'other@example.test', 'priority' => 100], app(UpdateMailRoute::class)))->toThrow(ModelNotFoundException::class);
+
+    $livewireRoute = app(CreateMailRoute::class)->execute(['team_id' => $team->getKey(), 'domain' => 'livewire-route.test', 'source_pattern' => 'support', 'destination' => 'ops@example.test']);
+    $inventory->deleteRoute($livewireRoute->getKey(), app(DeleteMailRoute::class));
+
+    $this->actingAs($user, 'sanctum')->deleteJson('/api/v1/control-panel/mail/routes/'.$foreign->getKey())->assertNotFound();
+    $this->actingAs($user, 'sanctum')->deleteJson('/api/v1/control-panel/mail/routes/'.$owned->getKey())->assertNoContent();
+
+    expect(MailRoute::query()->whereKey($owned->getKey())->exists())->toBeFalse()
+        ->and(MailRoute::query()->whereKey($livewireRoute->getKey())->exists())->toBeFalse();
 });

--- a/tests/Feature/MailModuleTest.php
+++ b/tests/Feature/MailModuleTest.php
@@ -6,13 +6,16 @@ use Illuminate\Validation\ValidationException;
 use Liberu\ControlPanel\Mail\Actions\ConfigureMailControls;
 use Liberu\ControlPanel\Mail\Actions\CreateMailAccount;
 use Liberu\ControlPanel\Mail\Actions\CreateMailAlias;
+use Liberu\ControlPanel\Mail\Actions\CreateMailRoute;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAccount;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailRoute;
 use Liberu\ControlPanel\Mail\Actions\RecordDeliveryDiagnostic;
 use Liberu\ControlPanel\Mail\Actions\RecordMailOperation;
 use Liberu\ControlPanel\Mail\Actions\RotateDkimKey;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAccount;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailRoute;
 use Liberu\ControlPanel\Mail\MailServiceProvider;
 use Liberu\ControlPanel\Mail\Models\DkimKey;
 use Liberu\ControlPanel\Mail\Models\MailAccount;
@@ -70,6 +73,33 @@ it('rejects alias updates without valid destinations', function (): void {
 
     expect(fn () => app(UpdateMailAlias::class)->execute($alias, ['destinations' => ['not-an-email']]))
         ->toThrow(ValidationException::class);
+});
+
+it('updates and deletes mail routes through domain actions', function (): void {
+    $route = app(CreateMailRoute::class)->execute([
+        'team_id' => 'team-1',
+        'domain' => 'example.test',
+        'source_pattern' => 'support',
+        'destination' => 'ops@example.test',
+    ]);
+
+    $updated = app(UpdateMailRoute::class)->execute($route, [
+        'domain' => 'mail.test',
+        'source_pattern' => 'helpdesk',
+        'destination' => 'team@example.test',
+        'priority' => 20,
+        'active' => false,
+    ]);
+
+    expect($updated->domain)->toBe('mail.test')
+        ->and($updated->source_pattern)->toBe('helpdesk')
+        ->and($updated->destination)->toBe('team@example.test')
+        ->and($updated->priority)->toBe(20)
+        ->and($updated->active)->toBeFalse();
+
+    app(DeleteMailRoute::class)->execute($updated);
+
+    expect($route->newQuery()->whereKey($route->getKey())->exists())->toBeFalse();
 });
 
 it('rotates DKIM keys without writing provider-specific mail configuration', function (): void {

--- a/tests/Feature/MailModuleTest.php
+++ b/tests/Feature/MailModuleTest.php
@@ -7,10 +7,12 @@ use Liberu\ControlPanel\Mail\Actions\ConfigureMailControls;
 use Liberu\ControlPanel\Mail\Actions\CreateMailAccount;
 use Liberu\ControlPanel\Mail\Actions\CreateMailAlias;
 use Liberu\ControlPanel\Mail\Actions\DeleteMailAccount;
+use Liberu\ControlPanel\Mail\Actions\DeleteMailAlias;
 use Liberu\ControlPanel\Mail\Actions\RecordDeliveryDiagnostic;
 use Liberu\ControlPanel\Mail\Actions\RecordMailOperation;
 use Liberu\ControlPanel\Mail\Actions\RotateDkimKey;
 use Liberu\ControlPanel\Mail\Actions\UpdateMailAccount;
+use Liberu\ControlPanel\Mail\Actions\UpdateMailAlias;
 use Liberu\ControlPanel\Mail\MailServiceProvider;
 use Liberu\ControlPanel\Mail\Models\DkimKey;
 use Liberu\ControlPanel\Mail\Models\MailAccount;
@@ -31,6 +33,43 @@ it('supports aliases, mailbox controls, spam and virus settings, and diagnostics
 it('rejects aliases without destinations and unsafe spam thresholds', function (): void {
     expect(fn () => app(CreateMailAlias::class)->execute(['team_id' => 'team-1', 'domain' => 'example.test', 'address' => 'support', 'destinations' => []]))->toThrow(ValidationException::class);
     expect(fn () => app(ConfigureMailControls::class)->execute(['team_id' => 'team-1', 'mail_account_id' => 'account-1', 'spam_threshold' => 99]))->toThrow(ValidationException::class);
+});
+
+it('updates and deletes aliases through domain actions', function (): void {
+    $alias = app(CreateMailAlias::class)->execute([
+        'team_id' => 'team-1',
+        'domain' => 'example.test',
+        'address' => 'support',
+        'destinations' => ['ops@example.test'],
+    ]);
+
+    $updated = app(UpdateMailAlias::class)->execute($alias, [
+        'domain' => 'mail.test',
+        'address' => 'helpdesk',
+        'destinations' => ['team@example.test', 'backup@example.test'],
+        'active' => false,
+    ]);
+
+    expect($updated->domain)->toBe('mail.test')
+        ->and($updated->address)->toBe('helpdesk')
+        ->and($updated->destinations)->toBe(['team@example.test', 'backup@example.test'])
+        ->and($updated->active)->toBeFalse();
+
+    app(DeleteMailAlias::class)->execute($updated);
+
+    expect($alias->newQuery()->whereKey($alias->getKey())->exists())->toBeFalse();
+});
+
+it('rejects alias updates without valid destinations', function (): void {
+    $alias = app(CreateMailAlias::class)->execute([
+        'team_id' => 'team-1',
+        'domain' => 'example.test',
+        'address' => 'support',
+        'destinations' => ['ops@example.test'],
+    ]);
+
+    expect(fn () => app(UpdateMailAlias::class)->execute($alias, ['destinations' => ['not-an-email']]))
+        ->toThrow(ValidationException::class);
 });
 
 it('rotates DKIM keys without writing provider-specific mail configuration', function (): void {


### PR DESCRIPTION
Implements the remaining mail-alias lifecycle surface across the modular stack:

- Adds tenant-safe update and delete actions.
- Adds API PATCH/DELETE endpoints and OpenAPI entries.
- Adds Filament and Livewire update/delete handling.
- Adds UUID model behavior and regression coverage for core, API, and Livewire tenant boundaries.

Verification: `php artisan test --compact` (410 passed, 12 skipped, 1,572 assertions).
`./vendor/bin/pint --dirty` passes.