### PR TITLE
Add file deletion lifecycle

### DIFF
--- a/modules/control-panel-files-api/openapi/v1/control-panel-files.yaml
+++ b/modules/control-panel-files-api/openapi/v1/control-panel-files.yaml
@@ -26,6 +26,7 @@ paths:
     post: {operationId: control.panel.files.quotas.create, security: [{sanctum: []}], responses: {'201': {description: File quota configured}}}
   /api/v1/control-panel/files/{file}:
     get: {operationId: control.panel.files.show, security: [{sanctum: []}], responses: {'200': {description: Authorized file record}}}
+    delete: {operationId: control.panel.files.delete, security: [{sanctum: []}], responses: {'200': {description: File marked deleted}}}
 components:
   securitySchemes:
     sanctum: {type: http, scheme: bearer, bearerFormat: Sanctum}

--- a/modules/control-panel-files-api/routes/api.php
+++ b/modules/control-panel-files-api/routes/api.php
@@ -14,5 +14,6 @@ Route::prefix('api/v1/control-panel/files')->middleware(['api', 'auth:sanctum', 
     Route::post('/sftp-accounts', [FileController::class, 'sftp'])->name('control-panel.files.sftp-accounts.store');
     Route::post('/retention', [FileController::class, 'retention'])->name('control-panel.files.retention.store');
     Route::post('/quotas', [FileController::class, 'quota'])->name('control-panel.files.quotas.store');
+    Route::delete('/{file}', [FileController::class, 'delete'])->name('control-panel.files.delete');
     Route::get('{file}', [FileController::class, 'show'])->name('control-panel.files.show');
 });

--- a/modules/control-panel-files-api/src/Http/Controllers/FileController.php
+++ b/modules/control-panel-files-api/src/Http/Controllers/FileController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Liberu\ControlPanel\Files\Actions\CreateHomeDirectory;
 use Liberu\ControlPanel\Files\Actions\CreateSftpAccount;
+use Liberu\ControlPanel\Files\Actions\DeleteFile;
 use Liberu\ControlPanel\Files\Actions\GrantFilePermission;
 use Liberu\ControlPanel\Files\Actions\RecordFileOperation;
 use Liberu\ControlPanel\Files\Actions\RegisterFile;
@@ -34,6 +35,16 @@ final class FileController
         $item = FileEntry::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
 
         return response()->json(['data' => ['id' => $item->getKey(), 'type' => 'control-panel-file', 'attributes' => $item->toArray()]]);
+    }
+
+    public function delete(Request $request, string $id, DeleteFile $delete): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $file = FileEntry::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
+        $delete->execute($file);
+
+        return response()->json(['data' => self::resource($file)]);
     }
 
     public function store(Request $request, RegisterFile $register): JsonResponse

--- a/modules/control-panel-files-filament/src/Resources/FileEntryResource.php
+++ b/modules/control-panel-files-filament/src/Resources/FileEntryResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\ControlPanel\FilesFilament\Resources;
 
+use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
@@ -11,6 +12,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Liberu\ControlPanel\Files\Actions\DeleteFile;
 use Liberu\ControlPanel\Files\Models\FileEntry;
 use Liberu\ControlPanel\FilesFilament\Resources\FileEntryResource\Pages\CreateFileEntry;
 use Liberu\ControlPanel\FilesFilament\Resources\FileEntryResource\Pages\EditFileEntry;
@@ -39,7 +41,11 @@ final class FileEntryResource extends Resource
 
     public static function table(Table $table): Table
     {
-        return $table->columns([TextColumn::make('path')->searchable()->sortable(), TextColumn::make('disk'), TextColumn::make('mime_type'), TextColumn::make('size_bytes')->numeric(), TextColumn::make('status')->badge(), TextColumn::make('scanned_at')->dateTime()])->defaultSort('created_at', 'desc');
+        return $table->columns([TextColumn::make('path')->searchable()->sortable(), TextColumn::make('disk'), TextColumn::make('mime_type'), TextColumn::make('size_bytes')->numeric(), TextColumn::make('status')->badge(), TextColumn::make('scanned_at')->dateTime()])->recordActions([
+            DeleteAction::make()
+                ->visible(fn (FileEntry $record): bool => $record->team_id === auth()->user()?->current_team_id && $record->status->value !== 'retained')
+                ->action(fn (FileEntry $record): FileEntry => app(DeleteFile::class)->execute($record)),
+        ])->defaultSort('created_at', 'desc');
     }
 
     public static function getEloquentQuery(): Builder

--- a/modules/control-panel-files-livewire/resources/views/components/file-inventory.blade.php
+++ b/modules/control-panel-files-livewire/resources/views/components/file-inventory.blade.php
@@ -3,7 +3,7 @@
     <input type="search" wire:model.live.debounce.300ms="search" placeholder="{{ __('Search files') }}">
     <ul>
         @forelse ($files as $file)
-            <li wire:key="file-{{ $file->getKey() }}">{{ $file->path }} — {{ $file->status->value }}</li>
+            <li wire:key="file-{{ $file->getKey() }}">{{ $file->path }} — {{ $file->status->value }} @if ($file->status->value !== 'retained') <button type="button" wire:click="delete('{{ $file->getKey() }}')">{{ __('Delete') }}</button> @endif</li>
         @empty
             <li>{{ __('No files found.') }}</li>
         @endforelse

--- a/modules/control-panel-files-livewire/src/Components/FileInventory.php
+++ b/modules/control-panel-files-livewire/src/Components/FileInventory.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\FilesLivewire\Components;
 
 use Illuminate\Contracts\View\View;
+use Liberu\ControlPanel\Files\Actions\DeleteFile;
+use Liberu\ControlPanel\Files\Models\FileEntry;
 use Liberu\ControlPanel\Files\Queries\ListFiles;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -20,6 +22,14 @@ final class FileInventory extends Component
     public function updatedSearch(): void
     {
         $this->resetPage();
+    }
+
+    public function delete(string $fileId, DeleteFile $delete): void
+    {
+        $teamId = auth()->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $file = FileEntry::query()->whereKey($fileId)->where('team_id', $teamId)->firstOrFail();
+        $delete->execute($file);
     }
 
     public function render(ListFiles $list): View

--- a/modules/control-panel-files/src/Actions/DeleteFile.php
+++ b/modules/control-panel-files/src/Actions/DeleteFile.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Files\Actions;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\Files\Enums\FileStatus;
+use Liberu\ControlPanel\Files\Models\FileEntry;
+
+final class DeleteFile
+{
+    public function execute(FileEntry $file): FileEntry
+    {
+        if ($file->status === FileStatus::Retained) {
+            throw ValidationException::withMessages(['file' => 'A retained file cannot be deleted.']);
+        }
+
+        $file->update(['status' => FileStatus::Deleted]);
+
+        return $file->refresh();
+    }
+}

--- a/modules/control-panel-files/src/FilesServiceProvider.php
+++ b/modules/control-panel-files/src/FilesServiceProvider.php
@@ -7,6 +7,7 @@ namespace Liberu\ControlPanel\Files;
 use Illuminate\Support\ServiceProvider;
 use Liberu\ControlPanel\Files\Actions\CreateHomeDirectory;
 use Liberu\ControlPanel\Files\Actions\CreateSftpAccount;
+use Liberu\ControlPanel\Files\Actions\DeleteFile;
 use Liberu\ControlPanel\Files\Actions\GrantFilePermission;
 use Liberu\ControlPanel\Files\Actions\RecordFileOperation;
 use Liberu\ControlPanel\Files\Actions\SetFileQuota;
@@ -18,6 +19,7 @@ final class FilesServiceProvider extends ServiceProvider
     {
         $this->app->scoped(CreateHomeDirectory::class);
         $this->app->scoped(CreateSftpAccount::class);
+        $this->app->scoped(DeleteFile::class);
         $this->app->scoped(GrantFilePermission::class);
         $this->app->scoped(RecordFileOperation::class);
         $this->app->scoped(SetFileRetention::class);

--- a/tests/Feature/ControlPanelFilesTest.php
+++ b/tests/Feature/ControlPanelFilesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\Files\Actions\DeleteFile;
 use Liberu\ControlPanel\Files\Actions\MarkFileScanned;
 use Liberu\ControlPanel\Files\Actions\RegisterFile;
 use Liberu\ControlPanel\Files\Enums\FileStatus;
@@ -40,4 +41,15 @@ it('marks a clean file available and an unsafe file quarantined', function (): v
 it('rejects absolute and traversal paths', function (): void {
     expect(fn () => app(RegisterFile::class)->execute(['path' => '/etc/passwd', 'disk' => 'local']))->toThrow(ValidationException::class)
         ->and(fn () => app(RegisterFile::class)->execute(['path' => '../secret', 'disk' => 'local']))->toThrow(ValidationException::class);
+});
+
+it('marks files deleted while protecting retained files', function (): void {
+    $file = app(RegisterFile::class)->execute(['team_id' => 'team-1', 'path' => 'home/index.html', 'disk' => 'local']);
+
+    expect(app(DeleteFile::class)->execute($file)->status)->toBe(FileStatus::Deleted);
+
+    $retained = app(RegisterFile::class)->execute(['team_id' => 'team-1', 'path' => 'home/retained.html', 'disk' => 'local']);
+    $retained->update(['status' => FileStatus::Retained]);
+
+    expect(fn () => app(DeleteFile::class)->execute($retained))->toThrow(ValidationException::class);
 });

--- a/tests/Feature/FilesModuleTest.php
+++ b/tests/Feature/FilesModuleTest.php
@@ -3,17 +3,21 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
 use Liberu\ControlPanel\Files\Actions\CreateHomeDirectory;
 use Liberu\ControlPanel\Files\Actions\CreateSftpAccount;
+use Liberu\ControlPanel\Files\Actions\DeleteFile;
 use Liberu\ControlPanel\Files\Actions\GrantFilePermission;
 use Liberu\ControlPanel\Files\Actions\RegisterFile;
 use Liberu\ControlPanel\Files\Actions\SetFileRetention;
+use Liberu\ControlPanel\Files\Enums\FileStatus;
 use Liberu\ControlPanel\Files\FilesServiceProvider;
 use Liberu\ControlPanel\Files\Queries\ListFiles;
 use Liberu\ControlPanel\FilesLivewire\Components\FileInventory;
 use Liberu\ControlPanel\FilesLivewire\FilesLivewireServiceProvider;
+use Liberu\Foundation\Organizations\Models\Team;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 uses(RefreshDatabase::class);
@@ -56,4 +60,20 @@ it('requires a current team before rendering the files inventory', function (): 
 
     expect(fn () => app(FileInventory::class)->render(app(ListFiles::class)))
         ->toThrow(HttpException::class);
+});
+
+it('deletes only a current-team file from Livewire', function (): void {
+    app()->register(FilesLivewireServiceProvider::class);
+    $team = Team::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $foreign = app(RegisterFile::class)->execute(['team_id' => $otherTeam->getKey(), 'path' => 'foreign.txt', 'disk' => 'local']);
+    $owned = app(RegisterFile::class)->execute(['team_id' => $team->getKey(), 'path' => 'owned.txt', 'disk' => 'local']);
+
+    $this->actingAs($user);
+    $inventory = app(FileInventory::class);
+    expect(fn () => $inventory->delete($foreign->getKey(), app(DeleteFile::class)))->toThrow(ModelNotFoundException::class);
+    $inventory->delete($owned->getKey(), app(DeleteFile::class));
+
+    expect($owned->refresh()->status)->toBe(FileStatus::Deleted);
 });

--- a/tests/Feature/FilesQuotaLifecycleTest.php
+++ b/tests/Feature/FilesQuotaLifecycleTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\Files\Actions\RegisterFile;
 use Liberu\ControlPanel\Files\Actions\SetFileQuota;
+use Liberu\ControlPanel\Files\Enums\FileStatus;
 use Liberu\ControlPanel\Files\FilesServiceProvider;
 use Liberu\ControlPanel\Files\Models\FileQuota;
 use Liberu\ControlPanel\FilesApi\FilesApiServiceProvider;
@@ -54,4 +56,17 @@ it('exposes quotas through the tenant-scoped API and Livewire component', functi
     $component->save(app(SetFileQuota::class));
 
     expect(FileQuota::query()->where('owner_id', 'owner-2')->where('team_id', $team->getKey())->exists())->toBeTrue();
+});
+
+it('deletes only a current-team file through the API', function (): void {
+    $team = Team::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $foreign = app(RegisterFile::class)->execute(['team_id' => $otherTeam->getKey(), 'path' => 'foreign.txt', 'disk' => 'local']);
+    $owned = app(RegisterFile::class)->execute(['team_id' => $team->getKey(), 'path' => 'owned.txt', 'disk' => 'local']);
+
+    $this->actingAs($user, 'sanctum')->deleteJson('/api/v1/control-panel/files/'.$foreign->getKey())->assertNotFound();
+    $this->actingAs($user, 'sanctum')->deleteJson('/api/v1/control-panel/files/'.$owned->getKey())->assertOk()->assertJsonPath('data.attributes.status', 'deleted');
+
+    expect($owned->refresh()->status)->toBe(FileStatus::Deleted);
 });


### PR DESCRIPTION
Adds the missing provider-neutral file deletion lifecycle.

- Adds a tenant-scoped soft-delete action and API endpoint
- Protects retained files from deletion
- Adds Filament and Livewire deletion controls
- Adds domain, API, and Livewire regression coverage

Full suite: 431 passed, 12 skipped, 1670 assertions.