### PR TITLE
Add maintenance window deletion lifecycle

### DIFF
--- a/modules/control-panel-monitoring-api/openapi/v1/control-panel-monitoring.yaml
+++ b/modules/control-panel-monitoring-api/openapi/v1/control-panel-monitoring.yaml
@@ -12,6 +12,8 @@ paths:
     post: {operationId: control.panel.monitoring.resources.create, security: [{sanctum: []}], responses: {'201': {$ref: '#/components/responses/Resource'}}}
   /api/v1/control-panel/monitoring/maintenance/{window}/cancel:
     post: {operationId: control.panel.monitoring.maintenance.cancel, security: [{sanctum: []}], responses: {'200': {description: Maintenance window cancelled}}}
+  /api/v1/control-panel/monitoring/maintenance/{window}:
+    delete: {operationId: control.panel.monitoring.maintenance.delete, security: [{sanctum: []}], responses: {'204': {description: Maintenance window deleted}}}
   /api/v1/control-panel/monitoring/{monitor}:
     get: {operationId: control.panel.monitoring.show, security: [{sanctum: []}], responses: {'200': {$ref: '#/components/responses/Resource'}}}
 components:

--- a/modules/control-panel-monitoring-api/routes/api.php
+++ b/modules/control-panel-monitoring-api/routes/api.php
@@ -12,5 +12,6 @@ Route::prefix('api/v1/control-panel/monitoring')->middleware(['api', 'auth:sanct
     Route::post('/events/{event}/resolve', [MonitorController::class, 'resolveEvent'])->name('control-panel.monitoring.events.resolve');
     Route::post('/resources', [MonitorController::class, 'record'])->name('control-panel.monitoring.resources.store');
     Route::post('/maintenance/{window}/cancel', [MonitorController::class, 'cancelMaintenance'])->name('control-panel.monitoring.maintenance.cancel');
+    Route::delete('/maintenance/{window}', [MonitorController::class, 'deleteMaintenance'])->name('control-panel.monitoring.maintenance.delete');
     Route::get('{monitor}', [MonitorController::class, 'show'])->name('control-panel.monitoring.show');
 });

--- a/modules/control-panel-monitoring-api/src/Http/Controllers/MonitorController.php
+++ b/modules/control-panel-monitoring-api/src/Http/Controllers/MonitorController.php
@@ -7,6 +7,7 @@ namespace Liberu\ControlPanel\MonitoringApi\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Liberu\ControlPanel\Monitoring\Actions\CancelMaintenanceWindow;
+use Liberu\ControlPanel\Monitoring\Actions\DeleteMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringEvent;
 use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringResource;
 use Liberu\ControlPanel\Monitoring\Actions\RegisterMonitor;
@@ -84,6 +85,16 @@ final class MonitorController
         abort_unless((string) $window->team_id === (string) $teamId, 404);
 
         return response()->json(['data' => ['id' => $window->getKey(), 'type' => 'control-panel-monitoring-maintenance', 'attributes' => $cancel->execute($window)->only(['name', 'starts_at', 'ends_at', 'scope', 'status', 'details'])]]);
+    }
+
+    public function deleteMaintenance(Request $request, string $id, DeleteMaintenanceWindow $delete): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $window = MaintenanceWindow::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
+        $delete->execute($window);
+
+        return response()->json(status: 204);
     }
 
     private static function resource(Monitor $item): array

--- a/modules/control-panel-monitoring-filament/src/Resources/MaintenanceWindowResource.php
+++ b/modules/control-panel-monitoring-filament/src/Resources/MaintenanceWindowResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\MonitoringFilament\Resources;
 
 use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\TextInput;
@@ -14,6 +15,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Liberu\ControlPanel\Monitoring\Actions\CancelMaintenanceWindow;
+use Liberu\ControlPanel\Monitoring\Actions\DeleteMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Models\MaintenanceWindow;
 use Liberu\ControlPanel\MonitoringFilament\Resources\MaintenanceWindowResource\Pages\CreateMaintenanceWindow;
 use Liberu\ControlPanel\MonitoringFilament\Resources\MaintenanceWindowResource\Pages\EditMaintenanceWindow;
@@ -36,6 +38,7 @@ final class MaintenanceWindowResource extends Resource
     {
         return $table->columns([TextColumn::make('name')->searchable()->sortable(), TextColumn::make('scope'), TextColumn::make('starts_at')->dateTime()->sortable(), TextColumn::make('ends_at')->dateTime(), TextColumn::make('status')->badge()])->recordActions([
             Action::make('cancel')->requiresConfirmation()->visible(fn (MaintenanceWindow $record): bool => ! in_array($record->status, ['cancelled', 'completed'], true))->action(fn (MaintenanceWindow $record): MaintenanceWindow => app(CancelMaintenanceWindow::class)->execute($record)),
+            DeleteAction::make()->visible(fn (MaintenanceWindow $record): bool => $record->team_id === auth()->user()?->current_team_id && ! in_array($record->status, ['active', 'completed'], true))->action(fn (MaintenanceWindow $record): void => app(DeleteMaintenanceWindow::class)->execute($record)),
         ])->defaultSort('starts_at', 'desc');
     }
 

--- a/modules/control-panel-monitoring-livewire/resources/views/components/monitoring-feature-inventory.blade.php
+++ b/modules/control-panel-monitoring-livewire/resources/views/components/monitoring-feature-inventory.blade.php
@@ -2,7 +2,7 @@
     <h2>{{ __('Maintenance windows') }}</h2>
     <ul>
         @forelse ($maintenance as $window)
-            <li wire:key="maintenance-{{ $window->getKey() }}">{{ $window->name }} — {{ $window->status }} @if (! in_array($window->status, ['cancelled', 'completed'], true))<button type="button" wire:click="cancelMaintenance('{{ $window->getKey() }}')" wire:loading.attr="disabled">{{ __('Cancel') }}</button>@endif</li>
+            <li wire:key="maintenance-{{ $window->getKey() }}">{{ $window->name }} — {{ $window->status }} @if (! in_array($window->status, ['cancelled', 'completed'], true))<button type="button" wire:click="cancelMaintenance('{{ $window->getKey() }}')" wire:loading.attr="disabled">{{ __('Cancel') }}</button>@endif @if (! in_array($window->status, ['active', 'completed'], true))<button type="button" wire:click="deleteMaintenance('{{ $window->getKey() }}')" wire:loading.attr="disabled">{{ __('Delete') }}</button>@endif</li>
         @empty
             <li>{{ __('No maintenance windows found.') }}</li>
         @endforelse

--- a/modules/control-panel-monitoring-livewire/src/Components/MonitoringFeatureInventory.php
+++ b/modules/control-panel-monitoring-livewire/src/Components/MonitoringFeatureInventory.php
@@ -6,6 +6,7 @@ namespace Liberu\ControlPanel\MonitoringLivewire\Components;
 
 use Illuminate\Contracts\View\View;
 use Liberu\ControlPanel\Monitoring\Actions\CancelMaintenanceWindow;
+use Liberu\ControlPanel\Monitoring\Actions\DeleteMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Actions\ResolveMonitoringEvent;
 use Liberu\ControlPanel\Monitoring\Models\MaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Models\MonitoringEvent;
@@ -19,6 +20,12 @@ final class MonitoringFeatureInventory extends Component
     {
         $window = MaintenanceWindow::query()->whereKey($windowId)->where('team_id', $this->teamId())->firstOrFail();
         $cancel->execute($window);
+    }
+
+    public function deleteMaintenance(string $windowId, DeleteMaintenanceWindow $delete): void
+    {
+        $window = MaintenanceWindow::query()->whereKey($windowId)->where('team_id', $this->teamId())->firstOrFail();
+        $delete->execute($window);
     }
 
     public function resolveEvent(string $eventId, ResolveMonitoringEvent $resolve): void

--- a/modules/control-panel-monitoring/src/Actions/DeleteMaintenanceWindow.php
+++ b/modules/control-panel-monitoring/src/Actions/DeleteMaintenanceWindow.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Monitoring\Actions;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\Monitoring\Models\MaintenanceWindow;
+
+final class DeleteMaintenanceWindow
+{
+    public function execute(MaintenanceWindow $window): void
+    {
+        if (in_array($window->status, ['active', 'completed'], true)) {
+            throw ValidationException::withMessages(['maintenance' => 'This maintenance window cannot be deleted.']);
+        }
+
+        $window->delete();
+    }
+}

--- a/modules/control-panel-monitoring/src/MonitoringServiceProvider.php
+++ b/modules/control-panel-monitoring/src/MonitoringServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\Monitoring;
 
 use Illuminate\Support\ServiceProvider;
+use Liberu\ControlPanel\Monitoring\Actions\DeleteMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringEvent;
 use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringResource;
 use Liberu\ControlPanel\Monitoring\Actions\RegisterMonitor;
@@ -15,6 +16,7 @@ final class MonitoringServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->app->scoped(DeleteMaintenanceWindow::class);
         $this->app->scoped(RegisterMonitor::class);
         $this->app->scoped(ListMonitors::class);
         $this->app->scoped(RecordMonitoringEvent::class);

--- a/tests/Feature/MonitoringMaintenanceLifecycleTest.php
+++ b/tests/Feature/MonitoringMaintenanceLifecycleTest.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
 use Liberu\ControlPanel\Monitoring\Actions\CancelMaintenanceWindow;
+use Liberu\ControlPanel\Monitoring\Actions\DeleteMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringResource;
 use Liberu\ControlPanel\Monitoring\Models\MaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\MonitoringServiceProvider;
@@ -28,6 +29,8 @@ it('cancels scheduled maintenance and rejects terminal repeats', function (): vo
     $cancelled = app(CancelMaintenanceWindow::class)->execute($window);
     expect($cancelled->status)->toBe('cancelled');
     expect(fn () => app(CancelMaintenanceWindow::class)->execute($cancelled))->toThrow(ValidationException::class);
+    app(DeleteMaintenanceWindow::class)->execute($cancelled);
+    expect(MaintenanceWindow::query()->whereKey($window->getKey())->exists())->toBeFalse();
 });
 
 it('cancels only a current-team maintenance window through API and Livewire', function (): void {
@@ -44,4 +47,6 @@ it('cancels only a current-team maintenance window through API and Livewire', fu
     $this->actingAs($user);
     app(MonitoringFeatureInventory::class)->cancelMaintenance($livewireWindow->getKey(), app(CancelMaintenanceWindow::class));
     expect(MaintenanceWindow::query()->findOrFail($livewireWindow->getKey())->status)->toBe('cancelled');
+    app(MonitoringFeatureInventory::class)->deleteMaintenance($livewireWindow->getKey(), app(DeleteMaintenanceWindow::class));
+    expect(MaintenanceWindow::query()->whereKey($livewireWindow->getKey())->exists())->toBeFalse();
 });


### PR DESCRIPTION
Adds tenant-scoped deletion for cancelled monitoring maintenance windows.

- Adds a domain deletion action with terminal-state protection
- Adds API DELETE/OpenAPI support
- Adds Filament and Livewire controls
- Extends lifecycle and tenant-boundary tests

Full suite: 432 passed, 12 skipped, 1677 assertions.