### PR TITLE
Add maintenance window updates

### DIFF
--- a/modules/control-panel-monitoring-api/openapi/v1/control-panel-monitoring.yaml
+++ b/modules/control-panel-monitoring-api/openapi/v1/control-panel-monitoring.yaml
@@ -13,6 +13,7 @@ paths:
   /api/v1/control-panel/monitoring/maintenance/{window}/cancel:
     post: {operationId: control.panel.monitoring.maintenance.cancel, security: [{sanctum: []}], responses: {'200': {description: Maintenance window cancelled}}}
   /api/v1/control-panel/monitoring/maintenance/{window}:
+    patch: {operationId: control.panel.monitoring.maintenance.update, security: [{sanctum: []}], responses: {'200': {description: Maintenance window updated}}}
     delete: {operationId: control.panel.monitoring.maintenance.delete, security: [{sanctum: []}], responses: {'204': {description: Maintenance window deleted}}}
   /api/v1/control-panel/monitoring/{monitor}:
     get: {operationId: control.panel.monitoring.show, security: [{sanctum: []}], responses: {'200': {$ref: '#/components/responses/Resource'}}}

--- a/modules/control-panel-monitoring-api/routes/api.php
+++ b/modules/control-panel-monitoring-api/routes/api.php
@@ -13,5 +13,6 @@ Route::prefix('api/v1/control-panel/monitoring')->middleware(['api', 'auth:sanct
     Route::post('/resources', [MonitorController::class, 'record'])->name('control-panel.monitoring.resources.store');
     Route::post('/maintenance/{window}/cancel', [MonitorController::class, 'cancelMaintenance'])->name('control-panel.monitoring.maintenance.cancel');
     Route::delete('/maintenance/{window}', [MonitorController::class, 'deleteMaintenance'])->name('control-panel.monitoring.maintenance.delete');
+    Route::patch('/maintenance/{window}', [MonitorController::class, 'updateMaintenance'])->name('control-panel.monitoring.maintenance.update');
     Route::get('{monitor}', [MonitorController::class, 'show'])->name('control-panel.monitoring.show');
 });

--- a/modules/control-panel-monitoring-api/src/Http/Controllers/MonitorController.php
+++ b/modules/control-panel-monitoring-api/src/Http/Controllers/MonitorController.php
@@ -12,6 +12,7 @@ use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringEvent;
 use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringResource;
 use Liberu\ControlPanel\Monitoring\Actions\RegisterMonitor;
 use Liberu\ControlPanel\Monitoring\Actions\ResolveMonitoringEvent;
+use Liberu\ControlPanel\Monitoring\Actions\UpdateMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Models\MaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Models\Monitor;
 use Liberu\ControlPanel\Monitoring\Models\MonitoringEvent;
@@ -95,6 +96,18 @@ final class MonitorController
         $delete->execute($window);
 
         return response()->json(status: 204);
+    }
+
+    public function updateMaintenance(Request $request, string $id, UpdateMaintenanceWindow $update): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $window = MaintenanceWindow::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
+        $data = $request->validate(['name' => ['sometimes', 'string', 'max:255'], 'starts_at' => ['sometimes', 'date'], 'ends_at' => ['sometimes', 'date'], 'scope' => ['sometimes', 'string', 'max:255'], 'details' => ['sometimes', 'array']]);
+
+        $window = $update->execute($window, $data);
+
+        return response()->json(['data' => ['id' => $window->getKey(), 'type' => 'control-panel-monitoring-maintenance', 'attributes' => $window->only(['name', 'starts_at', 'ends_at', 'scope', 'status', 'details'])]]);
     }
 
     private static function resource(Monitor $item): array

--- a/modules/control-panel-monitoring-filament/src/Resources/MaintenanceWindowResource/Pages/EditMaintenanceWindow.php
+++ b/modules/control-panel-monitoring-filament/src/Resources/MaintenanceWindowResource/Pages/EditMaintenanceWindow.php
@@ -5,9 +5,16 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\MonitoringFilament\Resources\MaintenanceWindowResource\Pages;
 
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\ControlPanel\Monitoring\Actions\UpdateMaintenanceWindow;
 use Liberu\ControlPanel\MonitoringFilament\Resources\MaintenanceWindowResource;
 
 final class EditMaintenanceWindow extends EditRecord
 {
     protected static string $resource = MaintenanceWindowResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        return app(UpdateMaintenanceWindow::class)->execute($record, $data);
+    }
 }

--- a/modules/control-panel-monitoring-livewire/src/Components/MonitoringFeatureInventory.php
+++ b/modules/control-panel-monitoring-livewire/src/Components/MonitoringFeatureInventory.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\View;
 use Liberu\ControlPanel\Monitoring\Actions\CancelMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Actions\DeleteMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Actions\ResolveMonitoringEvent;
+use Liberu\ControlPanel\Monitoring\Actions\UpdateMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Models\MaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Models\MonitoringEvent;
 use Livewire\Component;
@@ -26,6 +27,13 @@ final class MonitoringFeatureInventory extends Component
     {
         $window = MaintenanceWindow::query()->whereKey($windowId)->where('team_id', $this->teamId())->firstOrFail();
         $delete->execute($window);
+    }
+
+    /** @param array<string, mixed> $attributes */
+    public function updateMaintenance(string $windowId, array $attributes, UpdateMaintenanceWindow $update): void
+    {
+        $window = MaintenanceWindow::query()->whereKey($windowId)->where('team_id', $this->teamId())->firstOrFail();
+        $update->execute($window, $attributes);
     }
 
     public function resolveEvent(string $eventId, ResolveMonitoringEvent $resolve): void

--- a/modules/control-panel-monitoring/src/Actions/UpdateMaintenanceWindow.php
+++ b/modules/control-panel-monitoring/src/Actions/UpdateMaintenanceWindow.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Monitoring\Actions;
+
+use Carbon\Carbon;
+use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\Monitoring\Models\MaintenanceWindow;
+
+final class UpdateMaintenanceWindow
+{
+    /** @param array<string, mixed> $attributes */
+    public function execute(MaintenanceWindow $window, array $attributes): MaintenanceWindow
+    {
+        if (in_array($window->status, ['cancelled', 'completed'], true)) {
+            throw ValidationException::withMessages(['maintenance' => 'A terminal maintenance window cannot be updated.']);
+        }
+
+        $name = trim((string) ($attributes['name'] ?? $window->name));
+        $scope = trim((string) ($attributes['scope'] ?? $window->scope));
+        $startsAt = Carbon::parse($attributes['starts_at'] ?? $window->starts_at);
+        $endsAt = Carbon::parse($attributes['ends_at'] ?? $window->ends_at);
+        if ($name === '' || $scope === '' || $endsAt->lessThanOrEqualTo($startsAt)) {
+            throw ValidationException::withMessages(['maintenance' => 'A maintenance name, scope, and valid time range are required.']);
+        }
+
+        $window->forceFill(['name' => $name, 'starts_at' => $startsAt, 'ends_at' => $endsAt, 'scope' => $scope, 'details' => $attributes['details'] ?? $window->details])->save();
+
+        return $window->refresh();
+    }
+}

--- a/modules/control-panel-monitoring/src/MonitoringServiceProvider.php
+++ b/modules/control-panel-monitoring/src/MonitoringServiceProvider.php
@@ -10,6 +10,7 @@ use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringEvent;
 use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringResource;
 use Liberu\ControlPanel\Monitoring\Actions\RegisterMonitor;
 use Liberu\ControlPanel\Monitoring\Actions\ResolveMonitoringEvent;
+use Liberu\ControlPanel\Monitoring\Actions\UpdateMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Queries\ListMonitors;
 
 final class MonitoringServiceProvider extends ServiceProvider
@@ -22,6 +23,7 @@ final class MonitoringServiceProvider extends ServiceProvider
         $this->app->scoped(RecordMonitoringEvent::class);
         $this->app->scoped(RecordMonitoringResource::class);
         $this->app->scoped(ResolveMonitoringEvent::class);
+        $this->app->scoped(UpdateMaintenanceWindow::class);
     }
 
     public function boot(): void

--- a/tests/Feature/MonitoringMaintenanceLifecycleTest.php
+++ b/tests/Feature/MonitoringMaintenanceLifecycleTest.php
@@ -8,6 +8,7 @@ use Illuminate\Validation\ValidationException;
 use Liberu\ControlPanel\Monitoring\Actions\CancelMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Actions\DeleteMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Actions\RecordMonitoringResource;
+use Liberu\ControlPanel\Monitoring\Actions\UpdateMaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\Models\MaintenanceWindow;
 use Liberu\ControlPanel\Monitoring\MonitoringServiceProvider;
 use Liberu\ControlPanel\MonitoringApi\MonitoringApiServiceProvider;
@@ -31,6 +32,16 @@ it('cancels scheduled maintenance and rejects terminal repeats', function (): vo
     expect(fn () => app(CancelMaintenanceWindow::class)->execute($cancelled))->toThrow(ValidationException::class);
     app(DeleteMaintenanceWindow::class)->execute($cancelled);
     expect(MaintenanceWindow::query()->whereKey($window->getKey())->exists())->toBeFalse();
+});
+
+it('updates scheduled maintenance through the domain action', function (): void {
+    $window = app(RecordMonitoringResource::class)->execute(['team_id' => 'team-1', 'kind' => 'maintenance', 'name' => 'Upgrade', 'starts_at' => now()->addHour(), 'ends_at' => now()->addHours(2), 'scope' => 'cluster-1']);
+
+    $updated = app(UpdateMaintenanceWindow::class)->execute($window, ['name' => '延期', 'scope' => 'cluster-2', 'starts_at' => now()->addHours(3), 'ends_at' => now()->addHours(4)]);
+
+    expect($updated->name)->toBe('延期')->and($updated->scope)->toBe('cluster-2');
+    app(CancelMaintenanceWindow::class)->execute($updated);
+    expect(fn () => app(UpdateMaintenanceWindow::class)->execute($updated, ['name' => 'Blocked']))->toThrow(ValidationException::class);
 });
 
 it('cancels only a current-team maintenance window through API and Livewire', function (): void {


### PR DESCRIPTION
Adds domain-owned maintenance window updates across the monitoring module.

- Validates time ranges and blocks terminal windows
- Adds tenant-scoped API PATCH and OpenAPI contract
- Routes Filament edits through the domain action
- Adds Livewire update support and regression coverage

Full suite: 433 passed, 12 skipped, 1680 assertions.