### PR TITLE
Add certificate updates

### DIFF
--- a/modules/control-panel-certificates-api/openapi/v1/control-panel-certificates.yaml
+++ b/modules/control-panel-certificates-api/openapi/v1/control-panel-certificates.yaml
@@ -20,6 +20,7 @@ paths:
     post: {operationId: control.panel.certificates.lifecycle.record, security: [{sanctum: []}], responses: {'201': {description: Certificate lifecycle event recorded}}}
   /api/v1/control-panel/certificates/{certificate}:
     get: {operationId: control.panel.certificates.show, security: [{sanctum: []}], responses: {'200': {description: Authorized certificate}}}
+    patch: {operationId: control.panel.certificates.update, security: [{sanctum: []}], responses: {'200': {description: Certificate updated}}}
   /api/v1/control-panel/certificates/{certificate}/revoke:
     post:
       operationId: control.panel.certificates.revoke

--- a/modules/control-panel-certificates-api/routes/api.php
+++ b/modules/control-panel-certificates-api/routes/api.php
@@ -17,4 +17,5 @@ Route::prefix('api/v1/control-panel/certificates')->middleware(['api', 'auth:san
     Route::post('/{certificate}/expire', [CertificateController::class, 'expire'])->name('control-panel.certificates.expire');
     Route::post('/{certificate}/revoke', [CertificateController::class, 'revoke'])->name('control-panel.certificates.revoke');
     Route::get('/{certificate}', [CertificateController::class, 'show'])->name('control-panel.certificates.show');
+    Route::patch('/{certificate}', [CertificateController::class, 'update'])->name('control-panel.certificates.update');
 });

--- a/modules/control-panel-certificates-api/src/Http/Controllers/CertificateController.php
+++ b/modules/control-panel-certificates-api/src/Http/Controllers/CertificateController.php
@@ -15,6 +15,7 @@ use Liberu\ControlPanel\Certificates\Actions\RegisterCertificateLifecycle;
 use Liberu\ControlPanel\Certificates\Actions\RequestCertificateDeployment;
 use Liberu\ControlPanel\Certificates\Actions\RequestCertificateRenewal;
 use Liberu\ControlPanel\Certificates\Actions\RevokeCertificate;
+use Liberu\ControlPanel\Certificates\Actions\UpdateCertificate;
 use Liberu\ControlPanel\Certificates\Models\Certificate;
 use Liberu\ControlPanel\Certificates\Queries\ListCertificates;
 
@@ -36,6 +37,14 @@ final class CertificateController
         $item = Certificate::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
 
         return response()->json(['data' => ['id' => $item->getKey(), 'type' => 'control-panel-certificate', 'attributes' => $item->toArray()]]);
+    }
+
+    public function update(Request $request, string $id, UpdateCertificate $update): JsonResponse
+    {
+        $certificate = $this->findForTeam($request, $id);
+        $data = $request->validate(['domains' => ['sometimes', 'array', 'min:1'], 'domains.*' => ['string', 'max:253'], 'issuer' => ['sometimes', 'string', 'max:160'], 'expires_at' => ['sometimes', 'date', 'after:now'], 'metadata' => ['sometimes', 'array']]);
+
+        return response()->json(['data' => self::resource($update->execute($certificate, $data))]);
     }
 
     public function store(Request $request, IssueCertificate $issue): JsonResponse

--- a/modules/control-panel-certificates-filament/src/Resources/CertificateResource/Pages/EditCertificate.php
+++ b/modules/control-panel-certificates-filament/src/Resources/CertificateResource/Pages/EditCertificate.php
@@ -5,9 +5,16 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\CertificatesFilament\Resources\CertificateResource\Pages;
 
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\ControlPanel\Certificates\Actions\UpdateCertificate;
 use Liberu\ControlPanel\CertificatesFilament\Resources\CertificateResource;
 
 final class EditCertificate extends EditRecord
 {
     protected static string $resource = CertificateResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        return app(UpdateCertificate::class)->execute($record, $data);
+    }
 }

--- a/modules/control-panel-certificates-livewire/src/Components/CertificateInventory.php
+++ b/modules/control-panel-certificates-livewire/src/Components/CertificateInventory.php
@@ -5,12 +5,20 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\CertificatesLivewire\Components;
 
 use Illuminate\Contracts\View\View;
+use Liberu\ControlPanel\Certificates\Actions\UpdateCertificate;
 use Liberu\ControlPanel\Certificates\Models\Certificate;
 use Livewire\Component;
 
 final class CertificateInventory extends Component
 {
     public int $perPage = 25;
+
+    /** @param array<string, mixed> $attributes */
+    public function update(string $certificateId, array $attributes, UpdateCertificate $update): void
+    {
+        $certificate = Certificate::query()->whereKey($certificateId)->where('team_id', $this->teamId())->firstOrFail();
+        $update->execute($certificate, $attributes);
+    }
 
     public function render(): View
     {

--- a/modules/control-panel-certificates/src/Actions/UpdateCertificate.php
+++ b/modules/control-panel-certificates/src/Actions/UpdateCertificate.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Certificates\Actions;
+
+use Carbon\Carbon;
+use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\Certificates\Models\Certificate;
+
+final class UpdateCertificate
+{
+    /** @param array<string, mixed> $attributes */
+    public function execute(Certificate $certificate, array $attributes): Certificate
+    {
+        if (in_array($certificate->status->value, ['revoked', 'expired'], true)) {
+            throw ValidationException::withMessages(['certificate' => 'A terminal certificate cannot be updated.']);
+        }
+
+        $domains = array_values(array_filter(array_map(static fn (mixed $domain): string => strtolower(trim((string) $domain)), (array) ($attributes['domains'] ?? $certificate->domains))));
+        $issuer = trim((string) ($attributes['issuer'] ?? $certificate->issuer));
+        $expiresAt = Carbon::parse($attributes['expires_at'] ?? $certificate->expires_at);
+        if ($domains === [] || $issuer === '' || $expiresAt->isPast()) {
+            throw ValidationException::withMessages(['certificate' => 'At least one domain, an issuer, and a future expiry are required.']);
+        }
+
+        $certificate->forceFill(['domains' => $domains, 'issuer' => $issuer, 'expires_at' => $expiresAt, 'metadata' => $attributes['metadata'] ?? $certificate->metadata])->save();
+
+        return $certificate->refresh();
+    }
+}

--- a/modules/control-panel-certificates/src/CertificatesServiceProvider.php
+++ b/modules/control-panel-certificates/src/CertificatesServiceProvider.php
@@ -12,6 +12,7 @@ use Liberu\ControlPanel\Certificates\Actions\RegisterAcmeAccount;
 use Liberu\ControlPanel\Certificates\Actions\RegisterCertificateLifecycle;
 use Liberu\ControlPanel\Certificates\Actions\RequestCertificateDeployment;
 use Liberu\ControlPanel\Certificates\Actions\RequestCertificateRenewal;
+use Liberu\ControlPanel\Certificates\Actions\UpdateCertificate;
 
 final class CertificatesServiceProvider extends ServiceProvider
 {
@@ -29,5 +30,6 @@ final class CertificatesServiceProvider extends ServiceProvider
         $this->app->scoped(ExpireCertificate::class);
         $this->app->scoped(RequestCertificateDeployment::class);
         $this->app->scoped(RequestCertificateRenewal::class);
+        $this->app->scoped(UpdateCertificate::class);
     }
 }

--- a/tests/Feature/CertificatesLivewireActionsTest.php
+++ b/tests/Feature/CertificatesLivewireActionsTest.php
@@ -6,8 +6,10 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\ControlPanel\Certificates\Actions\ExpireCertificate;
 use Liberu\ControlPanel\Certificates\Actions\IssueCertificate;
+use Liberu\ControlPanel\Certificates\Actions\UpdateCertificate;
 use Liberu\ControlPanel\Certificates\CertificatesServiceProvider;
 use Liberu\ControlPanel\CertificatesLivewire\CertificatesLivewireServiceProvider;
+use Liberu\ControlPanel\CertificatesLivewire\Components\CertificateInventory;
 use Liberu\ControlPanel\CertificatesLivewire\Components\CertificateOperationInventory;
 use Liberu\Foundation\Organizations\Models\Team;
 
@@ -30,4 +32,15 @@ it('expires only a current-team certificate from Livewire', function (): void {
     app(CertificateOperationInventory::class)->expire($certificate->getKey(), app(ExpireCertificate::class));
 
     expect($certificate->refresh()->status->value)->toBe('expired');
+});
+
+it('updates only a current-team certificate from Livewire', function (): void {
+    $team = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $certificate = app(IssueCertificate::class)->execute(['team_id' => $team->getKey(), 'domains' => ['old.example.test']]);
+
+    $this->actingAs($user);
+    app(CertificateInventory::class)->update($certificate->getKey(), ['domains' => ['new.example.test'], 'issuer' => 'acme', 'expires_at' => now()->addDays(90)], app(UpdateCertificate::class));
+
+    expect($certificate->refresh()->domains)->toBe(['new.example.test']);
 });

--- a/tests/Feature/CertificatesModuleTest.php
+++ b/tests/Feature/CertificatesModuleTest.php
@@ -12,6 +12,7 @@ use Liberu\ControlPanel\Certificates\Actions\RegisterCertificateLifecycle;
 use Liberu\ControlPanel\Certificates\Actions\RequestCertificateDeployment;
 use Liberu\ControlPanel\Certificates\Actions\RequestCertificateRenewal;
 use Liberu\ControlPanel\Certificates\Actions\RevokeCertificate;
+use Liberu\ControlPanel\Certificates\Actions\UpdateCertificate;
 use Liberu\ControlPanel\Certificates\CertificatesServiceProvider;
 use Liberu\ControlPanel\Certificates\Enums\CertificateStatus;
 use Liberu\ControlPanel\CertificatesApi\CertificatesApiServiceProvider;
@@ -32,6 +33,15 @@ it('supports ACME, deployment, renewal, revocation operations, and expiry alerts
 });
 it('rejects unknown certificate lifecycle operations', function (): void {
     expect(fn () => app(RegisterCertificateLifecycle::class)->execute(['team_id' => 'team-1', 'kind' => 'unknown']))->toThrow(ValidationException::class);
+});
+
+it('updates active certificates and protects terminal certificates', function (): void {
+    $certificate = app(IssueCertificate::class)->execute(['team_id' => 'team-1', 'domains' => ['old.example.test']]);
+    $updated = app(UpdateCertificate::class)->execute($certificate, ['domains' => ['New.Example.test'], 'issuer' => 'acme-v2', 'expires_at' => now()->addDays(120)]);
+
+    expect($updated->domains)->toBe(['new.example.test'])->and($updated->issuer)->toBe('acme-v2');
+    app(RevokeCertificate::class)->execute($updated);
+    expect(fn () => app(UpdateCertificate::class)->execute($updated, ['issuer' => 'blocked']))->toThrow(ValidationException::class);
 });
 
 it('queues tenant-owned deployment and renewal workflows and records expiry state', function (): void {
@@ -104,6 +114,15 @@ it('exposes certificate lifecycle actions through a tenant-scoped API', function
     $this->actingAs($user, 'sanctum')
         ->postJson('/api/v1/control-panel/certificates/'.$otherCertificate->getKey().'/revoke')
         ->assertNotFound();
+
+    $this->actingAs($user, 'sanctum')
+        ->patchJson('/api/v1/control-panel/certificates/'.$otherCertificate->getKey(), ['issuer' => 'blocked'])
+        ->assertNotFound();
+
+    $this->actingAs($user, 'sanctum')
+        ->patchJson('/api/v1/control-panel/certificates/'.$certificate->getKey(), ['domains' => ['updated.example.test'], 'expires_at' => now()->addDays(120)])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.domains.0', 'updated.example.test');
 
     $expiredCertificate = app(IssueCertificate::class)->execute([
         'team_id' => $team->getKey(), 'domains' => ['expired.example.test'], 'expires_at' => now()->subMinute(),


### PR DESCRIPTION
Adds domain-owned certificate updates across the modular certificate stack.

- Normalizes domains and validates issuer and future expiry
- Blocks updates to revoked or expired certificates
- Adds tenant-scoped API PATCH/OpenAPI support
- Routes Filament edits and Livewire updates through the domain action
- Adds domain, API, and Livewire coverage

Full suite: 435 passed, 12 skipped, 1687 assertions.