### PR TITLE
Add security finding updates

### DIFF
--- a/modules/control-panel-security-api/openapi/v1/control-panel-security.yaml
+++ b/modules/control-panel-security-api/openapi/v1/control-panel-security.yaml
@@ -22,6 +22,7 @@ paths:
     post: {operationId: control.panel.security.compliance.create, security: [{sanctum: []}], responses: {'201': {$ref: '#/components/responses/Resource'}}}
   /api/v1/control-panel/security/{finding}:
     get: {operationId: control.panel.security.show, security: [{sanctum: []}], responses: {'200': {$ref: '#/components/responses/Resource'}}}
+    patch: {operationId: control.panel.security.update, security: [{sanctum: []}], responses: {'200': {$ref: '#/components/responses/Resource'}}}
 components:
   securitySchemes: {sanctum: {type: http, scheme: bearer, bearerFormat: Sanctum}}
   responses:

--- a/modules/control-panel-security-api/routes/api.php
+++ b/modules/control-panel-security-api/routes/api.php
@@ -9,6 +9,7 @@ Route::prefix('api/v1/control-panel/security')->middleware(['api', 'auth:sanctum
     Route::get('/', [SecurityFindingController::class, 'index'])->name('control-panel.security.index');
     Route::post('/', [SecurityFindingController::class, 'store'])->name('control-panel.security.store');
     Route::post('{finding}/resolve', [SecurityFindingController::class, 'resolve'])->name('control-panel.security.resolve');
+    Route::patch('{finding}', [SecurityFindingController::class, 'update'])->name('control-panel.security.update');
     Route::post('hardening', [SecurityFindingController::class, 'hardening'])->name('control-panel.security.hardening.store');
     Route::post('patches', [SecurityFindingController::class, 'patch'])->name('control-panel.security.patches.store');
     Route::post('mfa-rbac', [SecurityFindingController::class, 'policy'])->name('control-panel.security.mfa-rbac.store');

--- a/modules/control-panel-security-api/src/Http/Controllers/SecurityFindingController.php
+++ b/modules/control-panel-security-api/src/Http/Controllers/SecurityFindingController.php
@@ -10,6 +10,7 @@ use Liberu\ControlPanel\Security\Actions\RecordFinding;
 use Liberu\ControlPanel\Security\Actions\RecordSecurityResource;
 use Liberu\ControlPanel\Security\Actions\ResolveSecurityFinding;
 use Liberu\ControlPanel\Security\Actions\StoreSecret;
+use Liberu\ControlPanel\Security\Actions\UpdateSecurityFinding;
 use Liberu\ControlPanel\Security\Models\ComplianceStatus;
 use Liberu\ControlPanel\Security\Models\HardeningControl;
 use Liberu\ControlPanel\Security\Models\IntrusionControl;
@@ -56,6 +57,16 @@ final class SecurityFindingController
         $finding = SecurityFinding::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
 
         return response()->json(['data' => self::resource($resolve->execute($finding))]);
+    }
+
+    public function update(Request $request, string $id, UpdateSecurityFinding $update): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $finding = SecurityFinding::query()->whereKey($id)->where('team_id', $teamId)->firstOrFail();
+        $data = $request->validate(['subject_type' => ['sometimes', 'string', 'max:120'], 'subject_id' => ['sometimes', 'string', 'max:160'], 'code' => ['sometimes', 'string', 'max:120'], 'severity' => ['sometimes', 'in:critical,high,medium,low,info'], 'summary' => ['sometimes', 'string', 'max:255'], 'evidence' => ['sometimes', 'array']]);
+
+        return response()->json(['data' => self::resource($update->execute($finding, $data))]);
     }
 
     public function hardening(Request $request, RecordSecurityResource $record): JsonResponse

--- a/modules/control-panel-security-filament/src/Resources/SecurityFindingResource/Pages/EditSecurityFinding.php
+++ b/modules/control-panel-security-filament/src/Resources/SecurityFindingResource/Pages/EditSecurityFinding.php
@@ -5,9 +5,16 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\SecurityFilament\Resources\SecurityFindingResource\Pages;
 
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\ControlPanel\Security\Actions\UpdateSecurityFinding;
 use Liberu\ControlPanel\SecurityFilament\Resources\SecurityFindingResource;
 
 final class EditSecurityFinding extends EditRecord
 {
     protected static string $resource = SecurityFindingResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        return app(UpdateSecurityFinding::class)->execute($record, $data);
+    }
 }

--- a/modules/control-panel-security-livewire/src/Components/FindingInventory.php
+++ b/modules/control-panel-security-livewire/src/Components/FindingInventory.php
@@ -6,6 +6,7 @@ namespace Liberu\ControlPanel\SecurityLivewire\Components;
 
 use Illuminate\Contracts\View\View;
 use Liberu\ControlPanel\Security\Actions\ResolveSecurityFinding;
+use Liberu\ControlPanel\Security\Actions\UpdateSecurityFinding;
 use Liberu\ControlPanel\Security\Models\SecurityFinding;
 use Liberu\ControlPanel\Security\Queries\ListFindings;
 use Livewire\Component;
@@ -32,6 +33,13 @@ final class FindingInventory extends Component
             ->firstOrFail();
 
         $resolve->execute($finding);
+    }
+
+    /** @param array<string, mixed> $attributes */
+    public function update(string $findingId, array $attributes, UpdateSecurityFinding $update): void
+    {
+        $finding = SecurityFinding::query()->whereKey($findingId)->where('team_id', auth()->user()?->current_team_id)->firstOrFail();
+        $update->execute($finding, $attributes);
     }
 
     public function render(ListFindings $list): View

--- a/modules/control-panel-security/src/Actions/UpdateSecurityFinding.php
+++ b/modules/control-panel-security/src/Actions/UpdateSecurityFinding.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\Security\Actions;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\Security\Models\SecurityFinding;
+
+final class UpdateSecurityFinding
+{
+    /** @param array<string, mixed> $attributes */
+    public function execute(SecurityFinding $finding, array $attributes): SecurityFinding
+    {
+        if ($finding->status !== 'open') {
+            throw ValidationException::withMessages(['finding' => 'Only open security findings can be updated.']);
+        }
+
+        $subjectType = trim((string) ($attributes['subject_type'] ?? $finding->subject_type));
+        $subjectId = trim((string) ($attributes['subject_id'] ?? $finding->subject_id));
+        $code = trim((string) ($attributes['code'] ?? $finding->code));
+        $summary = trim((string) ($attributes['summary'] ?? $finding->summary));
+        $severity = (string) ($attributes['severity'] ?? $finding->severity);
+        if ($subjectType === '' || $subjectId === '' || $code === '' || $summary === '' || ! in_array($severity, ['critical', 'high', 'medium', 'low', 'info'], true)) {
+            throw ValidationException::withMessages(['finding' => 'A finding subject, code, severity, and summary are required.']);
+        }
+
+        $finding->forceFill(['subject_type' => $subjectType, 'subject_id' => $subjectId, 'code' => $code, 'severity' => $severity, 'summary' => $summary, 'evidence' => $attributes['evidence'] ?? $finding->evidence])->save();
+
+        return $finding->refresh();
+    }
+}

--- a/modules/control-panel-security/src/SecurityServiceProvider.php
+++ b/modules/control-panel-security/src/SecurityServiceProvider.php
@@ -9,6 +9,7 @@ use Liberu\ControlPanel\Security\Actions\RecordFinding;
 use Liberu\ControlPanel\Security\Actions\RecordSecurityResource;
 use Liberu\ControlPanel\Security\Actions\ResolveSecurityFinding;
 use Liberu\ControlPanel\Security\Actions\StoreSecret;
+use Liberu\ControlPanel\Security\Actions\UpdateSecurityFinding;
 use Liberu\ControlPanel\Security\Queries\ListFindings;
 
 final class SecurityServiceProvider extends ServiceProvider
@@ -20,6 +21,7 @@ final class SecurityServiceProvider extends ServiceProvider
         $this->app->scoped(ListFindings::class);
         $this->app->scoped(RecordSecurityResource::class);
         $this->app->scoped(StoreSecret::class);
+        $this->app->scoped(UpdateSecurityFinding::class);
     }
 
     public function boot(): void

--- a/tests/Feature/SecurityModuleTest.php
+++ b/tests/Feature/SecurityModuleTest.php
@@ -2,12 +2,15 @@
 
 declare(strict_types=1);
 
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
 use Liberu\ControlPanel\Security\Actions\RecordFinding;
 use Liberu\ControlPanel\Security\Actions\RecordSecurityResource;
 use Liberu\ControlPanel\Security\Actions\ResolveSecurityFinding;
 use Liberu\ControlPanel\Security\Actions\StoreSecret;
+use Liberu\ControlPanel\Security\Actions\UpdateSecurityFinding;
 use Liberu\ControlPanel\Security\Models\ComplianceStatus;
 use Liberu\ControlPanel\Security\Models\HardeningControl;
 use Liberu\ControlPanel\Security\Models\IntrusionControl;
@@ -16,6 +19,10 @@ use Liberu\ControlPanel\Security\Models\MfaRbacPolicy;
 use Liberu\ControlPanel\Security\Models\PatchRecord;
 use Liberu\ControlPanel\Security\Models\SecurityFinding;
 use Liberu\ControlPanel\Security\SecurityServiceProvider;
+use Liberu\ControlPanel\SecurityApi\SecurityApiServiceProvider;
+use Liberu\ControlPanel\SecurityLivewire\Components\FindingInventory;
+use Liberu\ControlPanel\SecurityLivewire\SecurityLivewireServiceProvider;
+use Liberu\Foundation\Organizations\Models\Team;
 
 uses(RefreshDatabase::class);
 
@@ -62,4 +69,32 @@ it('requires tenant context when recording security findings', function (): void
         'subject_type' => 'node', 'subject_id' => 'node-1',
         'code' => 'weak-ssh', 'severity' => 'high', 'summary' => 'SSH hardening is required',
     ]))->toThrow(ValidationException::class);
+});
+
+it('updates open findings and protects resolved findings', function (): void {
+    $finding = app(RecordFinding::class)->execute(['team_id' => 'team-1', 'subject_type' => 'node', 'subject_id' => 'node-1', 'code' => 'weak-ssh', 'severity' => 'high', 'summary' => 'SSH hardening is required']);
+    $updated = app(UpdateSecurityFinding::class)->execute($finding, ['severity' => 'critical', 'summary' => 'Immediate SSH hardening is required']);
+
+    expect($updated->severity)->toBe('critical')->and($updated->summary)->toBe('Immediate SSH hardening is required');
+    app(ResolveSecurityFinding::class)->execute($updated);
+    expect(fn () => app(UpdateSecurityFinding::class)->execute($updated, ['summary' => 'Blocked']))->toThrow(ValidationException::class);
+});
+
+it('updates only a current-team finding through API and Livewire', function (): void {
+    app()->register(SecurityApiServiceProvider::class);
+    app()->register(SecurityLivewireServiceProvider::class);
+    $team = Team::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $foreign = app(RecordFinding::class)->execute(['team_id' => $otherTeam->getKey(), 'subject_type' => 'node', 'subject_id' => 'foreign', 'code' => 'weak-ssh', 'severity' => 'high', 'summary' => 'Foreign finding']);
+    $owned = app(RecordFinding::class)->execute(['team_id' => $team->getKey(), 'subject_type' => 'node', 'subject_id' => 'owned', 'code' => 'weak-ssh', 'severity' => 'high', 'summary' => 'Owned finding']);
+
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/security/'.$foreign->getKey(), ['severity' => 'critical'])->assertNotFound();
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/security/'.$owned->getKey(), ['severity' => 'critical'])->assertOk()->assertJsonPath('data.attributes.severity', 'critical');
+
+    $inventory = app(FindingInventory::class);
+    expect(fn () => $inventory->update($foreign->getKey(), ['summary' => 'Blocked'], app(UpdateSecurityFinding::class)))->toThrow(ModelNotFoundException::class);
+    $inventory->update($owned->getKey(), ['summary' => 'Updated finding'], app(UpdateSecurityFinding::class));
+
+    expect($owned->refresh()->summary)->toBe('Updated finding');
 });


### PR DESCRIPTION
Adds a domain-owned update lifecycle for open security findings.

- Enforces tenant-scoped API and Livewire access
- Blocks updates after resolution
- Adds API PATCH/OpenAPI support
- Routes Filament edits through the domain action
- Applies security-audit guidance to validation and response boundaries

Full suite: 437 passed, 12 skipped, 1695 assertions.