### PR TITLE
Route hosting package edits through domain action

### DIFF
--- a/modules/control-panel-accounts-livewire/resources/views/components/feature-inventory.blade.php
+++ b/modules/control-panel-accounts-livewire/resources/views/components/feature-inventory.blade.php
@@ -2,6 +2,23 @@
     <h2 id="control-panel-account-feature-inventory">Account features</h2>
     <p>{{ $packages->count() }} packages and {{ $delegations->count() }} delegations.</p>
     <ul>
+        @foreach ($packages as $package)
+            <li wire:key="package-{{ $package->getKey() }}">
+                <form wire:submit="updatePackage('{{ $package->getKey() }}', null)" class="inline-flex gap-2">
+                    <label>
+                        <span class="sr-only">Package name</span>
+                        <input type="text" wire:model="packageEdits.{{ $package->getKey() }}.name" value="{{ $package->name }}" maxlength="160" required>
+                    </label>
+                    <label>
+                        <span>Active</span>
+                        <input type="checkbox" wire:model="packageEdits.{{ $package->getKey() }}.active" @checked($package->active)>
+                    </label>
+                    <button type="submit">Save package</button>
+                </form>
+            </li>
+        @endforeach
+    </ul>
+    <ul>
         @foreach ($delegations as $delegation)
             <li wire:key="delegation-{{ $delegation->getKey() }}">
                 {{ $delegation->delegate_id }} — {{ $delegation->active ? 'active' : 'revoked' }}

--- a/modules/control-panel-accounts-livewire/src/Components/AccountFeatureInventory.php
+++ b/modules/control-panel-accounts-livewire/src/Components/AccountFeatureInventory.php
@@ -7,6 +7,7 @@ namespace Liberu\ControlPanel\AccountsLivewire\Components;
 use Illuminate\Contracts\View\View;
 use Liberu\ControlPanel\Accounts\Actions\RevokeDelegation;
 use Liberu\ControlPanel\Accounts\Actions\UpdateDelegation;
+use Liberu\ControlPanel\Accounts\Actions\UpdateHostingPackage;
 use Liberu\ControlPanel\Accounts\Models\AccountDelegation;
 use Liberu\ControlPanel\Accounts\Models\HostingPackage;
 use Livewire\Component;
@@ -15,6 +16,27 @@ final class AccountFeatureInventory extends Component
 {
     /** @var array<string, array<string, mixed>> */
     public array $delegationEdits = [];
+
+    /** @var array<string, array<string, mixed>> */
+    public array $packageEdits = [];
+
+    /** @param array<string, mixed>|null $attributes */
+    public function updatePackage(string $packageId, ?array $attributes, UpdateHostingPackage $update): void
+    {
+        $package = HostingPackage::query()
+            ->whereKey($packageId)
+            ->where('team_id', $this->teamId())
+            ->firstOrFail();
+        $attributes ??= $this->packageEdits[$packageId] ?? [];
+        $attributes = validator($attributes, [
+            'name' => ['required', 'string', 'max:160'],
+            'limits' => ['nullable', 'array'],
+            'features' => ['nullable', 'array'],
+            'active' => ['sometimes', 'boolean'],
+        ])->validate();
+        $update->execute($package, $attributes);
+        unset($this->packageEdits[$packageId]);
+    }
 
     public function revokeDelegation(string $delegationId, RevokeDelegation $revoke): void
     {

--- a/tests/Feature/ControlPanelLivewireActionsTest.php
+++ b/tests/Feature/ControlPanelLivewireActionsTest.php
@@ -10,12 +10,15 @@ use Illuminate\Support\Str;
 use Liberu\ControlPanel\Accounts\AccountsServiceProvider;
 use Liberu\ControlPanel\Accounts\Actions\ArchiveAccount;
 use Liberu\ControlPanel\Accounts\Actions\CreateAccount;
+use Liberu\ControlPanel\Accounts\Actions\CreateHostingPackage;
 use Liberu\ControlPanel\Accounts\Actions\DelegateAccount;
 use Liberu\ControlPanel\Accounts\Actions\RevokeDelegation;
 use Liberu\ControlPanel\Accounts\Actions\SuspendAccount;
 use Liberu\ControlPanel\Accounts\Actions\UpdateDelegation;
+use Liberu\ControlPanel\Accounts\Actions\UpdateHostingPackage;
 use Liberu\ControlPanel\Accounts\Models\Account;
 use Liberu\ControlPanel\Accounts\Models\AccountDelegation;
+use Liberu\ControlPanel\Accounts\Models\HostingPackage;
 use Liberu\ControlPanel\AccountsLivewire\AccountsLivewireServiceProvider;
 use Liberu\ControlPanel\AccountsLivewire\Components\AccountFeatureInventory;
 use Liberu\ControlPanel\AccountsLivewire\Components\AccountInventory;
@@ -81,6 +84,23 @@ it('releases only a current-team operation lock owned by the supplied owner', fu
     $component->releaseLock($lock->getKey(), app(ReleaseOperationLock::class));
 
     expect(OperationLock::query()->find($lock->getKey()))->toBeNull();
+});
+
+it('updates only a current-team hosting package from the Livewire inventory', function (): void {
+    $team = Team::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $package = app(CreateHostingPackage::class)->execute(['team_id' => $team->getKey(), 'name' => 'Starter']);
+    $otherPackage = app(CreateHostingPackage::class)->execute(['team_id' => $otherTeam->getKey(), 'name' => 'Other']);
+
+    $this->actingAs($user);
+    $inventory = app(AccountFeatureInventory::class);
+    $inventory->updatePackage($package->getKey(), ['name' => 'Pro', 'active' => false], app(UpdateHostingPackage::class));
+
+    expect(HostingPackage::query()->find($package->getKey())->name)->toBe('Pro')
+        ->and(HostingPackage::query()->find($package->getKey())->active)->toBeFalse();
+    expect(fn () => $inventory->updatePackage($otherPackage->getKey(), ['name' => 'Nope'], app(UpdateHostingPackage::class)))
+        ->toThrow(ModelNotFoundException::class);
 });
 
 it('checks application health from the tenant-scoped hosting inventory', function (): void {


### PR DESCRIPTION
## Summary
- add tenant-scoped hosting package editing to the Accounts Livewire inventory
- route package edits through UpdateHostingPackage
- cover cross-team isolation and inactive package updates

## Verification
- ./vendor/bin/pint --dirty
- php artisan test (441 passed, 12 skipped)