### PR TITLE
Add API credential metadata updates

### DIFF
--- a/modules/control-panel-api-and-automation-api/openapi/v1/control-panel-api-and-automation.yaml
+++ b/modules/control-panel-api-and-automation-api/openapi/v1/control-panel-api-and-automation.yaml
@@ -8,6 +8,8 @@ paths:
       post: {operationId: control.panel.api.and.automation.templates.create, security: [{sanctum: []}], requestBody: {required: true, content: {application/json: {schema: {$ref: '#/components/schemas/TemplateCreate'}}}}, responses: {'201': {$ref: '#/components/responses/Resource'}}}
   /api/v1/control-panel/api-and-automation/credentials:
     post: {operationId: control.panel.api.and.automation.credentials.create, security: [{sanctum: []}], requestBody: {required: true, content: {application/json: {schema: {$ref: '#/components/schemas/CredentialCreate'}}}}, responses: {'201': {$ref: '#/components/responses/Resource'}}}
+  /api/v1/control-panel/api-and-automation/credentials/{credential}:
+    patch: {operationId: control.panel.api.and.automation.credentials.update, security: [{sanctum: []}], parameters: [{name: credential, in: path, required: true, schema: {type: string, format: uuid}}], requestBody: {required: true, content: {application/json: {schema: {$ref: '#/components/schemas/CredentialUpdate'}}}}, responses: {'200': {$ref: '#/components/responses/Resource'}}, '404': {description: Credential is outside the current team.}, '422': {description: Credential is not active.}}
   /api/v1/control-panel/api-and-automation/credentials/{credential}/revoke:
     post: {operationId: control.panel.api.and.automation.credentials.revoke, security: [{sanctum: []}], parameters: [{name: credential, in: path, required: true, schema: {type: string, format: uuid}}], responses: {'200': {$ref: '#/components/responses/Resource'}}, '404': {description: Credential is outside the current team.}, '422': {description: Credential is not active.}}
   /api/v1/control-panel/api-and-automation/webhooks:
@@ -40,6 +42,7 @@ components:
     Collection: {description: Authorized team-scoped resources without credentials, content: {application/json: {schema: {type: object}}}}
   schemas:
     CredentialCreate: {type: object, required: [name], properties: {name: {type: string, maxLength: 120}, scopes: {type: array, items: {type: string, maxLength: 120}}, secret: {type: string, writeOnly: true}, expires_at: {type: string, format: date-time}}}
+    CredentialUpdate: {type: object, properties: {name: {type: string, maxLength: 120}, scopes: {type: array, items: {type: string, maxLength: 120}}, expires_at: {type: string, format: date-time, nullable: true}}}
     WebhookCreate: {type: object, required: [name, url], properties: {name: {type: string, maxLength: 120}, url: {type: string, format: uri, pattern: '^https://'}, events: {type: array, items: {type: string, maxLength: 120}}, secret: {type: string, writeOnly: true}, retry_limit: {type: integer, minimum: 0, maximum: 20}}}
     WebhookUpdate: {type: object, properties: {name: {type: string, maxLength: 120}, url: {type: string, format: uri, pattern: '^https://'}, events: {type: array, items: {type: string, maxLength: 120}}, retry_limit: {type: integer, minimum: 0, maximum: 20}}}
     TemplateCreate: {type: object, required: [name, version, steps], properties: {name: {type: string, maxLength: 120}, version: {type: string, maxLength: 40}, description: {type: string}, inputs: {type: array}, steps: {type: array, minItems: 1}, active: {type: boolean}}}

--- a/modules/control-panel-api-and-automation-api/routes/api.php
+++ b/modules/control-panel-api-and-automation-api/routes/api.php
@@ -9,6 +9,7 @@ Route::prefix('api/v1/control-panel/api-and-automation')->middleware(['api', 'au
     Route::get('/', [AutomationController::class, 'index'])->name('control-panel.api-and-automation.index');
     Route::post('/', [AutomationController::class, 'store'])->name('control-panel.api-and-automation.store');
     Route::post('credentials', [AutomationController::class, 'credential'])->name('control-panel.api-and-automation.credentials.store');
+    Route::patch('credentials/{credential}', [AutomationController::class, 'updateCredential'])->name('control-panel.api-and-automation.credentials.update');
     Route::post('credentials/{credential}/revoke', [AutomationController::class, 'revokeCredential'])->name('control-panel.api-and-automation.credentials.revoke');
     Route::post('webhooks', [AutomationController::class, 'webhook'])->name('control-panel.api-and-automation.webhooks.store');
     Route::patch('webhooks/{webhook}', [AutomationController::class, 'updateWebhook'])->name('control-panel.api-and-automation.webhooks.update');

--- a/modules/control-panel-api-and-automation-api/src/Http/Controllers/AutomationController.php
+++ b/modules/control-panel-api-and-automation-api/src/Http/Controllers/AutomationController.php
@@ -18,6 +18,7 @@ use Liberu\ControlPanel\ApiAutomation\Actions\RegisterWebhook;
 use Liberu\ControlPanel\ApiAutomation\Actions\ResumeWebhook;
 use Liberu\ControlPanel\ApiAutomation\Actions\RevokeApiCredential;
 use Liberu\ControlPanel\ApiAutomation\Actions\StartOrchestration;
+use Liberu\ControlPanel\ApiAutomation\Actions\UpdateApiCredential;
 use Liberu\ControlPanel\ApiAutomation\Actions\UpdateWebhook;
 use Liberu\ControlPanel\ApiAutomation\Models\ApiCredential;
 use Liberu\ControlPanel\ApiAutomation\Models\AutomationDefinition;
@@ -82,6 +83,16 @@ final class AutomationController
         $item = ApiCredential::query()->whereKey($credential)->where('team_id', $teamId)->firstOrFail();
 
         return response()->json(['data' => self::credentialResource($revoke->execute($item))]);
+    }
+
+    public function updateCredential(Request $request, string $credential, UpdateApiCredential $update): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $item = ApiCredential::query()->whereKey($credential)->where('team_id', $teamId)->firstOrFail();
+        $data = $request->validate(['name' => ['sometimes', 'string', 'max:120'], 'scopes' => ['sometimes', 'array'], 'scopes.*' => ['string', 'max:120'], 'expires_at' => ['sometimes', 'nullable', 'date']]);
+
+        return response()->json(['data' => self::credentialResource($update->execute($item, $data))]);
     }
 
     public function updateWebhook(Request $request, string $webhook, UpdateWebhook $update): JsonResponse

--- a/modules/control-panel-api-and-automation-filament/src/Resources/ApiCredentialResource/Pages/EditApiCredential.php
+++ b/modules/control-panel-api-and-automation-filament/src/Resources/ApiCredentialResource/Pages/EditApiCredential.php
@@ -5,9 +5,21 @@ declare(strict_types=1);
 namespace Liberu\ControlPanel\ApiAutomationFilament\Resources\ApiCredentialResource\Pages;
 
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\ControlPanel\ApiAutomation\Actions\UpdateApiCredential;
+use Liberu\ControlPanel\ApiAutomation\Models\ApiCredential;
 use Liberu\ControlPanel\ApiAutomationFilament\Resources\ApiCredentialResource;
 
 final class EditApiCredential extends EditRecord
 {
     protected static string $resource = ApiCredentialResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var ApiCredential $record */
+        abort_if(auth()->user()?->current_team_id === null, 403, 'A current team is required.');
+        abort_unless((string) $record->team_id === (string) auth()->user()?->current_team_id, 404);
+
+        return app(UpdateApiCredential::class)->execute($record, $data);
+    }
 }

--- a/modules/control-panel-api-and-automation-livewire/resources/views/components/credential-inventory.blade.php
+++ b/modules/control-panel-api-and-automation-livewire/resources/views/components/credential-inventory.blade.php
@@ -7,7 +7,10 @@
         <ul>
             @foreach ($credentials as $credential)
                 <li wire:key="api-credential-{{ $credential->getKey() }}">
-                    <span>{{ $credential->name }}</span>
+                    <form wire:submit="update('{{ $credential->getKey() }}', null)" class="inline-flex gap-2">
+                        <input type="text" wire:model="edits.{{ $credential->getKey() }}.name" value="{{ $credential->name }}" maxlength="120" required>
+                        <button type="submit">{{ __('Save') }}</button>
+                    </form>
                     <span>{{ $credential->status }}</span>
                     @if ($credential->status === 'active')
                         <button type="button" wire:click="revoke('{{ $credential->getKey() }}')">{{ __('Revoke') }}</button>

--- a/modules/control-panel-api-and-automation-livewire/src/Components/CredentialInventory.php
+++ b/modules/control-panel-api-and-automation-livewire/src/Components/CredentialInventory.php
@@ -6,6 +6,7 @@ namespace Liberu\ControlPanel\ApiAutomationLivewire\Components;
 
 use Illuminate\Contracts\View\View;
 use Liberu\ControlPanel\ApiAutomation\Actions\RevokeApiCredential;
+use Liberu\ControlPanel\ApiAutomation\Actions\UpdateApiCredential;
 use Liberu\ControlPanel\ApiAutomation\Models\ApiCredential;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -13,6 +14,21 @@ use Livewire\WithPagination;
 final class CredentialInventory extends Component
 {
     use WithPagination;
+
+    /** @var array<string, array<string, mixed>> */
+    public array $edits = [];
+
+    /** @param array<string, mixed>|null $attributes */
+    public function update(string $credentialId, ?array $attributes, UpdateApiCredential $update): void
+    {
+        $teamId = auth()->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $credential = ApiCredential::query()->whereKey($credentialId)->where('team_id', $teamId)->firstOrFail();
+        $attributes ??= $this->edits[$credentialId] ?? [];
+        $attributes = validator($attributes, ['name' => ['required', 'string', 'max:120'], 'scopes' => ['nullable', 'array'], 'expires_at' => ['nullable', 'date']])->validate();
+        $update->execute($credential, $attributes);
+        unset($this->edits[$credentialId]);
+    }
 
     public function revoke(string $credentialId, RevokeApiCredential $revoke): void
     {

--- a/modules/control-panel-api-and-automation/src/Actions/UpdateApiCredential.php
+++ b/modules/control-panel-api-and-automation/src/Actions/UpdateApiCredential.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\ApiAutomation\Actions;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\ApiAutomation\Models\ApiCredential;
+
+final class UpdateApiCredential
+{
+    /** @param array<string, mixed> $attributes */
+    public function execute(ApiCredential $credential, array $attributes): ApiCredential
+    {
+        if ($credential->status !== 'active') {
+            throw ValidationException::withMessages(['credential' => 'Only active credentials can be updated.']);
+        }
+
+        $name = trim((string) ($attributes['name'] ?? $credential->name));
+        if ($name === '') {
+            throw ValidationException::withMessages(['name' => 'A credential name is required.']);
+        }
+
+        $credential->forceFill(['name' => $name, 'scopes' => $attributes['scopes'] ?? $credential->scopes, 'expires_at' => $attributes['expires_at'] ?? $credential->expires_at])->save();
+
+        return $credential->refresh();
+    }
+}

--- a/modules/control-panel-api-and-automation/src/ApiAutomationServiceProvider.php
+++ b/modules/control-panel-api-and-automation/src/ApiAutomationServiceProvider.php
@@ -16,6 +16,7 @@ use Liberu\ControlPanel\ApiAutomation\Actions\RegisterWebhook;
 use Liberu\ControlPanel\ApiAutomation\Actions\ResumeWebhook;
 use Liberu\ControlPanel\ApiAutomation\Actions\RevokeApiCredential;
 use Liberu\ControlPanel\ApiAutomation\Actions\StartOrchestration;
+use Liberu\ControlPanel\ApiAutomation\Actions\UpdateApiCredential;
 use Liberu\ControlPanel\ApiAutomation\Queries\ListAutomations;
 use Liberu\ControlPanel\ApiAutomation\Queries\ListWebhooks;
 
@@ -27,6 +28,7 @@ final class ApiAutomationServiceProvider extends ServiceProvider
         $this->app->scoped(ListAutomations::class);
         $this->app->scoped(RegisterApiCredential::class);
         $this->app->scoped(RevokeApiCredential::class);
+        $this->app->scoped(UpdateApiCredential::class);
         $this->app->scoped(RegisterWebhook::class);
         $this->app->scoped(PauseWebhook::class);
         $this->app->scoped(ResumeWebhook::class);

--- a/tests/Feature/ApiAutomationApiTest.php
+++ b/tests/Feature/ApiAutomationApiTest.php
@@ -82,6 +82,17 @@ it('revokes only a current-team API credential through the API', function (): vo
         ->assertUnprocessable();
 });
 
+it('updates only a current-team API credential through the API', function (): void {
+    $team = Team::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $credential = app(RegisterApiCredential::class)->execute(['team_id' => $team->getKey(), 'name' => 'Deploy']);
+    $otherCredential = app(RegisterApiCredential::class)->execute(['team_id' => $otherTeam->getKey(), 'name' => 'Other']);
+
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/api-and-automation/credentials/'.$otherCredential->getKey(), ['name' => 'Nope'])->assertNotFound();
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/api-and-automation/credentials/'.$credential->getKey(), ['name' => 'Release', 'scopes' => ['release']])->assertOk()->assertJsonPath('data.attributes.name', 'Release')->assertJsonMissingPath('data.attributes.secret');
+});
+
 it('updates only a current-team webhook through the API', function (): void {
     $team = Team::factory()->create();
     $otherTeam = Team::factory()->create();

--- a/tests/Feature/ApiAutomationModuleTest.php
+++ b/tests/Feature/ApiAutomationModuleTest.php
@@ -10,6 +10,7 @@ use Liberu\ControlPanel\ApiAutomation\Actions\RegisterWebhook;
 use Liberu\ControlPanel\ApiAutomation\Actions\ResumeWebhook;
 use Liberu\ControlPanel\ApiAutomation\Actions\RevokeApiCredential;
 use Liberu\ControlPanel\ApiAutomation\Actions\StartOrchestration;
+use Liberu\ControlPanel\ApiAutomation\Actions\UpdateApiCredential;
 use Liberu\ControlPanel\ApiAutomation\Actions\UpdateWebhook;
 use Liberu\ControlPanel\ApiAutomation\ApiAutomationServiceProvider;
 use Liberu\ControlPanel\ApiAutomation\Models\AutomationTemplate;
@@ -37,6 +38,13 @@ it('revokes an active API credential and rejects repeat revocation', function ()
     expect(app(RevokeApiCredential::class)->execute($credential)->status)->toBe('revoked')
         ->and(fn () => app(RevokeApiCredential::class)->execute($credential->refresh()))
         ->toThrow(ValidationException::class);
+});
+
+it('updates active API credential metadata without exposing its secret', function (): void {
+    $credential = app(RegisterApiCredential::class)->execute(['team_id' => 'team-1', 'name' => 'Deploy', 'secret' => 'hidden']);
+    $updated = app(UpdateApiCredential::class)->execute($credential, ['name' => 'Release', 'scopes' => ['release']]);
+
+    expect($updated->name)->toBe('Release')->and($updated->scopes)->toBe(['release'])->and($updated->secret)->toBe('hidden');
 });
 
 it('rejects insecure webhook endpoints and makes orchestration idempotent', function (): void {


### PR DESCRIPTION
## Summary
- add a domain-owned update action for active API credential metadata
- expose tenant-scoped API, Filament, and Livewire update flows
- preserve secret redaction and cover wrong-team access

## Verification
- ./vendor/bin/pint --dirty
- focused API/domain/Livewire tests (16 passed, 48 assertions)
- full suite before this additive slice (441 passed, 12 skipped)