### PR TITLE
Add node credential metadata updates

### DIFF
--- a/modules/control-panel-control-core-api/openapi/v1/control-panel-control-core.yaml
+++ b/modules/control-panel-control-core-api/openapi/v1/control-panel-control-core.yaml
@@ -66,6 +66,12 @@ paths:
       security: [{sanctum: []}]
       parameters: [{name: credential, in: path, required: true, schema: {type: string, format: uuid}}]
       responses: {'200': {description: Credential expired.}, '422': {description: Credential expiration is invalid.}}
+  /api/v1/control-panel/control-core/credentials/{credential}:
+    patch:
+      operationId: control.panel.control.core.credentials.update
+      security: [{sanctum: []}]
+      parameters: [{name: credential, in: path, required: true, schema: {type: string, format: uuid}}]
+      responses: {'200': {description: Credential updated.}, '404': {description: Credential is outside the current team.}, '422': {description: Credential is not active.}}
   /api/v1/control-panel/control-core/tasks:
     get: {summary: List operation tasks, responses: {'200': {description: Authorized task collection.}}}
     post: {summary: Queue an idempotent operation, responses: {'201': {description: Task queued.}}}

--- a/modules/control-panel-control-core-api/routes/api.php
+++ b/modules/control-panel-control-core-api/routes/api.php
@@ -21,6 +21,7 @@ Route::prefix('api/v1/control-panel/control-core')
         Route::put('nodes/{node}/capabilities', [NodeController::class, 'capabilities'])->name('control-panel.control-core.nodes.capabilities');
         Route::post('nodes/{node}/credentials', [NodeController::class, 'credential'])->name('control-panel.control-core.nodes.credentials.store');
         Route::post('credentials/{credential}/revoke', [NodeController::class, 'revokeCredential'])->name('control-panel.control-core.credentials.revoke');
+        Route::patch('credentials/{credential}', [NodeController::class, 'updateCredential'])->name('control-panel.control-core.credentials.update');
         Route::post('credentials/{credential}/expire', [NodeController::class, 'expireCredential'])->name('control-panel.control-core.credentials.expire');
         Route::get('tasks', [OperationTaskController::class, 'index'])->name('control-panel.control-core.tasks.index');
         Route::post('tasks', [OperationTaskController::class, 'store'])->name('control-panel.control-core.tasks.store');

--- a/modules/control-panel-control-core-api/src/Http/Controllers/NodeController.php
+++ b/modules/control-panel-control-core-api/src/Http/Controllers/NodeController.php
@@ -14,6 +14,7 @@ use Liberu\ControlPanel\ControlCore\Actions\RegisterNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\RevokeNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\SyncNodeCapabilities;
 use Liberu\ControlPanel\ControlCore\Actions\UpdateDesiredState;
+use Liberu\ControlPanel\ControlCore\Actions\UpdateNodeCredential;
 use Liberu\ControlPanel\ControlCore\Enums\NodeStatus;
 use Liberu\ControlPanel\ControlCore\Models\Node;
 use Liberu\ControlPanel\ControlCore\Models\NodeCredential;
@@ -130,6 +131,16 @@ final class NodeController
         $item = NodeCredential::query()->whereKey($credential)->where('team_id', $teamId)->firstOrFail();
 
         return response()->json(['data' => $this->credentialResource($revoke->execute($item))]);
+    }
+
+    public function updateCredential(Request $request, string $credential, UpdateNodeCredential $update): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_if($teamId === null, 403, 'A current team is required.');
+        $item = NodeCredential::query()->whereKey($credential)->where('team_id', $teamId)->firstOrFail();
+        $data = $request->validate(['name' => ['sometimes', 'string', 'max:160'], 'username' => ['sometimes', 'nullable', 'string', 'alpha_dash', 'max:120'], 'expires_at' => ['sometimes', 'nullable', 'date'], 'metadata' => ['sometimes', 'array']]);
+
+        return response()->json(['data' => $this->credentialResource($update->execute($item, $data))]);
     }
 
     public function expireCredential(Request $request, string $credential, ExpireNodeCredential $expire): JsonResponse

--- a/modules/control-panel-control-core-filament/src/Resources/NodeCredentialResource.php
+++ b/modules/control-panel-control-core-filament/src/Resources/NodeCredentialResource.php
@@ -18,6 +18,7 @@ use Liberu\ControlPanel\ControlCore\Actions\RevokeNodeCredential;
 use Liberu\ControlPanel\ControlCore\Models\Node;
 use Liberu\ControlPanel\ControlCore\Models\NodeCredential;
 use Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource\Pages\CreateNodeCredential;
+use Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource\Pages\EditNodeCredential;
 use Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource\Pages\ListNodeCredentials;
 
 final class NodeCredentialResource extends Resource
@@ -78,6 +79,7 @@ final class NodeCredentialResource extends Resource
         return [
             'index' => ListNodeCredentials::route('/'),
             'create' => CreateNodeCredential::route('/create'),
+            'edit' => EditNodeCredential::route('/{record}/edit'),
         ];
     }
 }

--- a/modules/control-panel-control-core-filament/src/Resources/NodeCredentialResource/Pages/EditNodeCredential.php
+++ b/modules/control-panel-control-core-filament/src/Resources/NodeCredentialResource/Pages/EditNodeCredential.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource\Pages;
+
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\ControlPanel\ControlCore\Actions\UpdateNodeCredential;
+use Liberu\ControlPanel\ControlCore\Models\NodeCredential;
+use Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource;
+
+final class EditNodeCredential extends EditRecord
+{
+    protected static string $resource = NodeCredentialResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var NodeCredential $record */
+        abort_if(auth()->user()?->current_team_id === null, 403, 'A current team is required.');
+        abort_unless((string) $record->team_id === (string) auth()->user()->current_team_id, 404);
+
+        return app(UpdateNodeCredential::class)->execute($record, $data);
+    }
+}

--- a/modules/control-panel-control-core-livewire/resources/views/components/credential-inventory.blade.php
+++ b/modules/control-panel-control-core-livewire/resources/views/components/credential-inventory.blade.php
@@ -32,7 +32,10 @@
         <ul>
             @foreach ($credentials as $credential)
                 <li wire:key="credential-{{ $credential->getKey() }}">
-                    <span>{{ $credential->name }}</span>
+                    <form wire:submit="update('{{ $credential->getKey() }}', null)">
+                        <input type="text" wire:model="edits.{{ $credential->getKey() }}.name" value="{{ $credential->name }}" maxlength="160" required>
+                        <button type="submit">{{ __('Save') }}</button>
+                    </form>
                     <span>{{ $credential->type }}</span>
                     <span>{{ $credential->status->value }}</span>
                     @if ($credential->status->value !== 'revoked')

--- a/modules/control-panel-control-core-livewire/src/Components/CredentialInventory.php
+++ b/modules/control-panel-control-core-livewire/src/Components/CredentialInventory.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\View;
 use Liberu\ControlPanel\ControlCore\Actions\ExpireNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\RevokeNodeCredential;
+use Liberu\ControlPanel\ControlCore\Actions\UpdateNodeCredential;
 use Liberu\ControlPanel\ControlCore\Models\NodeCredential;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -23,6 +24,19 @@ final class CredentialInventory extends Component
     public string $username = '';
 
     public string $publicKey = '';
+
+    /** @var array<string, array<string, mixed>> */
+    public array $edits = [];
+
+    /** @param array<string, mixed>|null $attributes */
+    public function update(string $credentialId, ?array $attributes, UpdateNodeCredential $update): void
+    {
+        $credential = NodeCredential::query()->whereKey($credentialId)->where('team_id', $this->teamId())->firstOrFail();
+        $attributes ??= $this->edits[$credentialId] ?? [];
+        $attributes = validator($attributes, ['name' => ['required', 'string', 'max:160'], 'username' => ['nullable', 'string', 'alpha_dash', 'max:120'], 'expires_at' => ['nullable', 'date'], 'metadata' => ['nullable', 'array']])->validate();
+        $update->execute($credential, $attributes);
+        unset($this->edits[$credentialId]);
+    }
 
     public function createCredential(RegisterNodeCredential $register): void
     {

--- a/modules/control-panel-control-core/src/Actions/UpdateNodeCredential.php
+++ b/modules/control-panel-control-core/src/Actions/UpdateNodeCredential.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\ControlCore\Actions;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\ControlCore\Enums\CredentialStatus;
+use Liberu\ControlPanel\ControlCore\Models\NodeCredential;
+
+final class UpdateNodeCredential
+{
+    /** @param array<string, mixed> $attributes */
+    public function execute(NodeCredential $credential, array $attributes): NodeCredential
+    {
+        if ($credential->status !== CredentialStatus::Active) {
+            throw ValidationException::withMessages(['credential' => 'Only active credentials can be updated.']);
+        }
+
+        $name = trim((string) ($attributes['name'] ?? $credential->name));
+        if ($name === '') {
+            throw ValidationException::withMessages(['name' => 'A credential name is required.']);
+        }
+
+        $credential->forceFill([
+            'name' => $name,
+            'username' => $attributes['username'] ?? $credential->username,
+            'expires_at' => $attributes['expires_at'] ?? $credential->expires_at,
+            'metadata' => $attributes['metadata'] ?? $credential->metadata,
+        ])->save();
+
+        return $credential->refresh();
+    }
+}

--- a/modules/control-panel-control-core/src/ControlCoreServiceProvider.php
+++ b/modules/control-panel-control-core/src/ControlCoreServiceProvider.php
@@ -17,6 +17,7 @@ use Liberu\ControlPanel\ControlCore\Actions\RevokeNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\SyncNodeCapabilities;
 use Liberu\ControlPanel\ControlCore\Actions\TransitionOperationTask;
 use Liberu\ControlPanel\ControlCore\Actions\UpdateDesiredState;
+use Liberu\ControlPanel\ControlCore\Actions\UpdateNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\WriteAuditEntry;
 use Liberu\ControlPanel\ControlCore\Queries\ListAuditEntries;
 use Liberu\ControlPanel\ControlCore\Queries\ListInventory;
@@ -38,6 +39,7 @@ final class ControlCoreServiceProvider extends ServiceProvider
         $this->app->scoped(ListInventory::class);
         $this->app->scoped(SyncNodeCapabilities::class);
         $this->app->scoped(UpdateDesiredState::class);
+        $this->app->scoped(UpdateNodeCredential::class);
         $this->app->scoped(TransitionOperationTask::class);
         $this->app->scoped(WriteAuditEntry::class);
         $this->app->scoped(ListAuditEntries::class);

--- a/tests/Feature/ControlCoreCredentialsTest.php
+++ b/tests/Feature/ControlCoreCredentialsTest.php
@@ -8,10 +8,12 @@ use Illuminate\Validation\ValidationException;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNode;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\RevokeNodeCredential;
+use Liberu\ControlPanel\ControlCore\Actions\UpdateNodeCredential;
 use Liberu\ControlPanel\ControlCore\ControlCoreServiceProvider;
 use Liberu\ControlPanel\ControlCore\Enums\CredentialStatus;
 use Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource;
 use Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource\Pages\CreateNodeCredential;
+use Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource\Pages\EditNodeCredential;
 
 uses(RefreshDatabase::class);
 
@@ -43,6 +45,15 @@ it('registers encrypted managed credentials and supports revocation', function (
     expect($revoked->status)->toBe(CredentialStatus::Revoked);
 });
 
+it('updates active credential metadata without changing its secret', function (): void {
+    $node = app(RegisterNode::class)->execute(['team_id' => 'team-1', 'name' => 'Managed node', 'hostname' => 'node.test']);
+    $credential = app(RegisterNodeCredential::class)->execute(['team_id' => 'team-1', 'node_id' => $node->getKey(), 'name' => 'Deploy key', 'secret' => 'a-secret-value']);
+    $updated = app(UpdateNodeCredential::class)->execute($credential, ['name' => 'Release key', 'username' => 'deploy']);
+
+    expect($updated->name)->toBe('Release key')->and($updated->username)->toBe('deploy')->and($updated->secret)->toBe('a-secret-value');
+});
+
 it('exposes a tenant-scoped Filament create workflow for node credentials', function (): void {
     expect(NodeCredentialResource::getPages()['create']->getPage())->toBe(CreateNodeCredential::class);
+    expect(NodeCredentialResource::getPages()['edit']->getPage())->toBe(EditNodeCredential::class);
 });

--- a/tests/Feature/ControlCoreTest.php
+++ b/tests/Feature/ControlCoreTest.php
@@ -139,6 +139,20 @@ it('expires a credential through the tenant-scoped API', function (): void {
         ->assertJsonPath('data.attributes.status', 'expired');
 });
 
+it('updates only a current-team credential through the API', function (): void {
+    app()->register(ControlCoreApiServiceProvider::class);
+    $team = Team::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $node = app(RegisterNode::class)->execute(['team_id' => $team->getKey(), 'name' => 'API node', 'hostname' => 'api.test']);
+    $credential = app(RegisterNodeCredential::class)->execute(['team_id' => $team->getKey(), 'node_id' => $node->getKey(), 'name' => 'API key', 'secret' => 'long-enough-secret']);
+    $otherNode = app(RegisterNode::class)->execute(['team_id' => $otherTeam->getKey(), 'name' => 'Other node', 'hostname' => 'other.test']);
+    $otherCredential = app(RegisterNodeCredential::class)->execute(['team_id' => $otherTeam->getKey(), 'node_id' => $otherNode->getKey(), 'name' => 'Other key', 'secret' => 'long-enough-secret']);
+
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/control-core/credentials/'.$otherCredential->getKey(), ['name' => 'Nope'])->assertNotFound();
+    $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/control-core/credentials/'.$credential->getKey(), ['name' => 'Release key', 'username' => 'deploy'])->assertOk()->assertJsonPath('data.attributes.name', 'Release key')->assertJsonMissingPath('data.attributes.secret');
+});
+
 it('never exposes credentials through a node query', function (): void {
     $node = Node::query()->create([
         'team_id' => 'team-1',

--- a/tests/Feature/ControlPanelLivewireActionsTest.php
+++ b/tests/Feature/ControlPanelLivewireActionsTest.php
@@ -31,6 +31,7 @@ use Liberu\ControlPanel\ControlCore\Actions\RegisterNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\ReleaseOperationLock;
 use Liberu\ControlPanel\ControlCore\Actions\RevokeNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\TransitionOperationTask;
+use Liberu\ControlPanel\ControlCore\Actions\UpdateNodeCredential;
 use Liberu\ControlPanel\ControlCore\ControlCoreServiceProvider;
 use Liberu\ControlPanel\ControlCore\Enums\NodeStatus;
 use Liberu\ControlPanel\ControlCore\Enums\TaskStatus;
@@ -131,6 +132,22 @@ it('revokes only a current-team credential from the Livewire inventory', functio
     app(CredentialInventory::class)->revoke($credential->getKey(), app(RevokeNodeCredential::class));
 
     expect($credential->fresh()->status->value)->toBe('revoked');
+});
+
+it('updates only a current-team credential from the Livewire inventory', function (): void {
+    $team = Team::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $node = app(RegisterNode::class)->execute(['team_id' => $team->getKey(), 'name' => 'Node', 'hostname' => 'node.test']);
+    $credential = app(RegisterNodeCredential::class)->execute(['team_id' => $team->getKey(), 'node_id' => $node->getKey(), 'name' => 'Deploy', 'secret' => 'long-enough-secret']);
+    $otherNode = app(RegisterNode::class)->execute(['team_id' => $otherTeam->getKey(), 'name' => 'Other', 'hostname' => 'other.test']);
+    $otherCredential = app(RegisterNodeCredential::class)->execute(['team_id' => $otherTeam->getKey(), 'node_id' => $otherNode->getKey(), 'name' => 'Other', 'secret' => 'long-enough-secret']);
+
+    $this->actingAs($user);
+    $inventory = app(CredentialInventory::class);
+    $inventory->update($credential->getKey(), ['name' => 'Release', 'username' => 'deploy'], app(UpdateNodeCredential::class));
+    expect($credential->fresh()->name)->toBe('Release');
+    expect(fn () => $inventory->update($otherCredential->getKey(), ['name' => 'Nope'], app(UpdateNodeCredential::class)))->toThrow(ModelNotFoundException::class);
 });
 
 it('registers a tenant-scoped SSH public key from the Livewire inventory', function (): void {


### PR DESCRIPTION
## Summary
- add a domain-owned update action for active node credential metadata
- expose tenant-scoped API, Filament, and Livewire update workflows
- preserve encrypted secrets and cover wrong-team access

## Verification
- ./vendor/bin/pint --dirty
- focused Control Core and architecture checks (43 passed, 460 assertions)