### PR TITLE
Add ephemeral SSH key pair generation

### DIFF
--- a/modules/control-panel-control-core-api/openapi/v1/control-panel-control-core.yaml
+++ b/modules/control-panel-control-core-api/openapi/v1/control-panel-control-core.yaml
@@ -60,6 +60,11 @@ paths:
       security: [{sanctum: []}]
       parameters: [{name: credential, in: path, required: true, schema: {type: string, format: uuid}}]
       responses: {'200': {description: Credential revoked.}}
+  /api/v1/control-panel/control-core/credentials/generate-key-pair:
+    post:
+      operationId: control.panel.control.core.credentials.generate.key.pair
+      security: [{sanctum: []}]
+      responses: {'201': {description: Ephemeral SSH key pair generated.}, '422': {description: Invalid key parameters.}}
   /api/v1/control-panel/control-core/credentials/{credential}/expire:
     post:
       operationId: control.panel.control.core.credentials.expire

--- a/modules/control-panel-control-core-api/routes/api.php
+++ b/modules/control-panel-control-core-api/routes/api.php
@@ -20,6 +20,7 @@ Route::prefix('api/v1/control-panel/control-core')
         Route::post('nodes/{node}/decommission', [NodeController::class, 'decommission'])->name('control-panel.control-core.nodes.decommission');
         Route::put('nodes/{node}/capabilities', [NodeController::class, 'capabilities'])->name('control-panel.control-core.nodes.capabilities');
         Route::post('nodes/{node}/credentials', [NodeController::class, 'credential'])->name('control-panel.control-core.nodes.credentials.store');
+        Route::post('credentials/generate-key-pair', [NodeController::class, 'generateKeyPair'])->name('control-panel.control-core.credentials.generate-key-pair');
         Route::post('credentials/{credential}/revoke', [NodeController::class, 'revokeCredential'])->name('control-panel.control-core.credentials.revoke');
         Route::patch('credentials/{credential}', [NodeController::class, 'updateCredential'])->name('control-panel.control-core.credentials.update');
         Route::post('credentials/{credential}/expire', [NodeController::class, 'expireCredential'])->name('control-panel.control-core.credentials.expire');

--- a/modules/control-panel-control-core-api/src/Http/Controllers/NodeController.php
+++ b/modules/control-panel-control-core-api/src/Http/Controllers/NodeController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Liberu\ControlPanel\ControlCore\Actions\ChangeNodeStatus;
 use Liberu\ControlPanel\ControlCore\Actions\DecommissionNode;
 use Liberu\ControlPanel\ControlCore\Actions\ExpireNodeCredential;
+use Liberu\ControlPanel\ControlCore\Actions\GenerateSshKeyPair;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNode;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\RevokeNodeCredential;
@@ -122,6 +123,21 @@ final class NodeController
         ]);
 
         return response()->json(['data' => $this->credentialResource($register->execute(array_merge($data, ['team_id' => $teamId, 'node_id' => $item->getKey()])))], 201);
+    }
+
+    public function generateKeyPair(Request $request, GenerateSshKeyPair $generate): JsonResponse
+    {
+        abort_if($request->user()?->current_team_id === null, 403, 'A current team is required.');
+        $data = $request->validate([
+            'passphrase' => ['nullable', 'string', 'min:8', 'max:4096'],
+            'bits' => ['nullable', 'integer', 'in:2048,4096'],
+            'comment' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        return response()->json(['data' => [
+            'type' => 'control-panel-ssh-key-pair',
+            'attributes' => $generate->execute($data['passphrase'] ?? null, (int) ($data['bits'] ?? 4096), $data['comment'] ?? null),
+        ]], 201);
     }
 
     public function revokeCredential(Request $request, string $credential, RevokeNodeCredential $revoke): JsonResponse

--- a/modules/control-panel-control-core-filament/src/Resources/NodeCredentialResource/Pages/ListNodeCredentials.php
+++ b/modules/control-panel-control-core-filament/src/Resources/NodeCredentialResource/Pages/ListNodeCredentials.php
@@ -4,10 +4,30 @@ declare(strict_types=1);
 
 namespace Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource\Pages;
 
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Liberu\ControlPanel\ControlCore\Actions\GenerateSshKeyPair;
 use Liberu\ControlPanel\ControlCoreFilament\Resources\NodeCredentialResource;
 
 final class ListNodeCredentials extends ListRecords
 {
     protected static string $resource = NodeCredentialResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [Action::make('generateKeyPair')
+            ->label('Generate SSH key pair')
+            ->form([
+                TextInput::make('passphrase')->password()->minLength(8),
+                Select::make('bits')->options([2048 => '2048', 4096 => '4096'])->default(4096)->required(),
+                TextInput::make('comment')->maxLength(255),
+            ])
+            ->action(function (array $data): void {
+                $pair = app(GenerateSshKeyPair::class)->execute($data['passphrase'] ?? null, (int) $data['bits'], $data['comment'] ?? null);
+                Notification::make()->title('SSH key pair generated')->body("Public key:\n{$pair['public_key']}\n\nPrivate key:\n{$pair['private_key']}")->persistent()->success()->send();
+            })];
+    }
 }

--- a/modules/control-panel-control-core-livewire/resources/views/components/credential-inventory.blade.php
+++ b/modules/control-panel-control-core-livewire/resources/views/components/credential-inventory.blade.php
@@ -26,6 +26,23 @@
         <button type="submit">{{ __('Register credential') }}</button>
     </form>
 
+    <form wire:submit="generateKeyPair" aria-labelledby="control-core-key-generation">
+        <h3 id="control-core-key-generation">Generate an SSH key pair</h3>
+        <label>Passphrase <input type="password" wire:model="keyPassphrase" minlength="8"></label>
+        @error('keyPassphrase') <p role="alert">{{ $message }}</p> @enderror
+        <label>Bits <select wire:model="keyBits"><option value="2048">2048</option><option value="4096">4096</option></select></label>
+        <label>Comment <input type="text" wire:model="keyComment" maxlength="255"></label>
+        <button type="submit">{{ __('Generate key pair') }}</button>
+    </form>
+
+    @if ($generatedPrivateKey !== '')
+        <aside aria-label="Generated SSH key pair">
+            <p role="alert">{{ __('Save the private key now. It is not stored by the control panel.') }}</p>
+            <label>Public key <textarea readonly>{{ $generatedPublicKey }}</textarea></label>
+            <label>Private key <textarea readonly>{{ $generatedPrivateKey }}</textarea></label>
+        </aside>
+    @endif
+
     @if ($credentials->isEmpty())
         <p>No managed node credentials are registered for the current team.</p>
     @else

--- a/modules/control-panel-control-core-livewire/src/Components/CredentialInventory.php
+++ b/modules/control-panel-control-core-livewire/src/Components/CredentialInventory.php
@@ -6,6 +6,7 @@ namespace Liberu\ControlPanel\ControlCoreLivewire\Components;
 
 use Illuminate\Contracts\View\View;
 use Liberu\ControlPanel\ControlCore\Actions\ExpireNodeCredential;
+use Liberu\ControlPanel\ControlCore\Actions\GenerateSshKeyPair;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\RevokeNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\UpdateNodeCredential;
@@ -24,6 +25,28 @@ final class CredentialInventory extends Component
     public string $username = '';
 
     public string $publicKey = '';
+
+    public string $generatedPrivateKey = '';
+
+    public string $generatedPublicKey = '';
+
+    public string $keyPassphrase = '';
+
+    public int $keyBits = 4096;
+
+    public string $keyComment = '';
+
+    public function generateKeyPair(GenerateSshKeyPair $generate): void
+    {
+        $data = $this->validate([
+            'keyPassphrase' => ['nullable', 'string', 'min:8', 'max:4096'],
+            'keyBits' => ['required', 'integer', 'in:2048,4096'],
+            'keyComment' => ['nullable', 'string', 'max:255'],
+        ]);
+        $pair = $generate->execute($data['keyPassphrase'] ?: null, $data['keyBits'], $data['keyComment'] ?: null);
+        $this->generatedPrivateKey = $pair['private_key'];
+        $this->generatedPublicKey = $pair['public_key'];
+    }
 
     /** @var array<string, array<string, mixed>> */
     public array $edits = [];

--- a/modules/control-panel-control-core/composer.json
+++ b/modules/control-panel-control-core/composer.json
@@ -8,6 +8,7 @@
     "php": "^8.5",
     "illuminate/database": "^13.0",
     "illuminate/support": "^13.0",
+    "phpseclib/phpseclib": "^3.0",
     "liberusoftware/module-manager": "^1.0"
   },
   "autoload": {

--- a/modules/control-panel-control-core/src/Actions/GenerateSshKeyPair.php
+++ b/modules/control-panel-control-core/src/Actions/GenerateSshKeyPair.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\ControlPanel\ControlCore\Actions;
+
+use Illuminate\Validation\ValidationException;
+use phpseclib3\Crypt\RSA;
+
+final class GenerateSshKeyPair
+{
+    /** @return array{public_key: string, private_key: string} */
+    public function execute(?string $passphrase = null, int $bits = 4096, ?string $comment = null): array
+    {
+        if (! in_array($bits, [2048, 4096], true)) {
+            throw ValidationException::withMessages(['bits' => 'RSA keys must use 2048 or 4096 bits.']);
+        }
+
+        if ($passphrase !== null && $passphrase !== '' && mb_strlen($passphrase) < 8) {
+            throw ValidationException::withMessages(['passphrase' => 'The passphrase must contain at least 8 characters.']);
+        }
+
+        if ($comment !== null && mb_strlen($comment) > 255) {
+            throw ValidationException::withMessages(['comment' => 'The comment may not exceed 255 characters.']);
+        }
+
+        $key = RSA::createKey($bits);
+        $publicKey = $key->getPublicKey()->toString('OpenSSH', array_filter(['comment' => $comment]));
+
+        if ($passphrase !== null && $passphrase !== '') {
+            $key = $key->withPassword($passphrase);
+        }
+
+        return [
+            'public_key' => $publicKey,
+            'private_key' => $key->toString('PKCS8'),
+        ];
+    }
+}

--- a/modules/control-panel-control-core/src/ControlCoreServiceProvider.php
+++ b/modules/control-panel-control-core/src/ControlCoreServiceProvider.php
@@ -9,6 +9,7 @@ use Liberu\ControlPanel\ControlCore\Actions\AcquireOperationLock;
 use Liberu\ControlPanel\ControlCore\Actions\CreateOperationTask;
 use Liberu\ControlPanel\ControlCore\Actions\DecommissionNode;
 use Liberu\ControlPanel\ControlCore\Actions\ExpireNodeCredential;
+use Liberu\ControlPanel\ControlCore\Actions\GenerateSshKeyPair;
 use Liberu\ControlPanel\ControlCore\Actions\RecordInventory;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNode;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNodeCredential;
@@ -32,6 +33,7 @@ final class ControlCoreServiceProvider extends ServiceProvider
         $this->app->scoped(CreateOperationTask::class);
         $this->app->scoped(DecommissionNode::class);
         $this->app->scoped(ExpireNodeCredential::class);
+        $this->app->scoped(GenerateSshKeyPair::class);
         $this->app->scoped(RecordInventory::class);
         $this->app->scoped(AcquireOperationLock::class);
         $this->app->scoped(ListNodes::class);

--- a/tests/Feature/ControlCoreCredentialsTest.php
+++ b/tests/Feature/ControlCoreCredentialsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
+use Liberu\ControlPanel\ControlCore\Actions\GenerateSshKeyPair;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNode;
 use Liberu\ControlPanel\ControlCore\Actions\RegisterNodeCredential;
 use Liberu\ControlPanel\ControlCore\Actions\RevokeNodeCredential;
@@ -56,4 +57,12 @@ it('updates active credential metadata without changing its secret', function ()
 it('exposes a tenant-scoped Filament create workflow for node credentials', function (): void {
     expect(NodeCredentialResource::getPages()['create']->getPage())->toBe(CreateNodeCredential::class);
     expect(NodeCredentialResource::getPages()['edit']->getPage())->toBe(EditNodeCredential::class);
+});
+
+it('generates an ephemeral encrypted SSH key pair', function (): void {
+    $pair = app(GenerateSshKeyPair::class)->execute('a-secure-passphrase', 2048, 'deploy');
+
+    expect($pair['public_key'])->toStartWith('ssh-rsa ')
+        ->and($pair['public_key'])->toEndWith(' deploy')
+        ->and($pair['private_key'])->toContain('BEGIN ENCRYPTED PRIVATE KEY');
 });

--- a/tests/Feature/ControlCoreTest.php
+++ b/tests/Feature/ControlCoreTest.php
@@ -153,6 +153,23 @@ it('updates only a current-team credential through the API', function (): void {
     $this->actingAs($user, 'sanctum')->patchJson('/api/v1/control-panel/control-core/credentials/'.$credential->getKey(), ['name' => 'Release key', 'username' => 'deploy'])->assertOk()->assertJsonPath('data.attributes.name', 'Release key')->assertJsonMissingPath('data.attributes.secret');
 });
 
+it('generates an SSH key pair through the tenant-scoped API', function (): void {
+    app()->register(ControlCoreApiServiceProvider::class);
+    $team = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->getKey()]);
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/control-panel/control-core/credentials/generate-key-pair', [
+            'bits' => 2048,
+            'passphrase' => 'a-secure-passphrase',
+            'comment' => 'deploy',
+        ])
+        ->assertCreated()
+        ->assertJsonPath('data.type', 'control-panel-ssh-key-pair')
+        ->assertJsonPath('data.attributes.public_key', fn (string $key): bool => str_starts_with($key, 'ssh-rsa '))
+        ->assertJsonPath('data.attributes.private_key', fn (string $key): bool => str_contains($key, 'BEGIN ENCRYPTED PRIVATE KEY'));
+});
+
 it('never exposes credentials through a node query', function (): void {
     $node = Node::query()->create([
         'team_id' => 'team-1',


### PR DESCRIPTION
## Summary\n- add provider-neutral RSA SSH key generation with optional encryption\n- expose one-time key generation through the Control Core API, Livewire, and Filament\n- document and test the tenant-scoped API contract\n\n## Verification\n- php artisan test --compact tests/Feature/ControlCoreTest.php tests/Feature/ControlCoreCredentialsTest.php tests/Feature/ControlPanelLivewireActionsTest.php\n- composer validate --no-check-publish\n- git diff --check