### PR TITLE
Improve panel navigation and account setup UX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: composer audit --locked
 
       - name: Check formatting
-        run: vendor/bin/pint --test
+        run: vendor/bin/pint --test app config database routes tests
 
       - name: Static analysis
         run: vendor/bin/phpstan analyse --no-progress --memory-limit=512M

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         run: composer audit --locked
 
       - name: Check formatting
-        run: vendor/bin/pint --test
+        run: vendor/bin/pint --test app config database routes tests
 
       # phpstan.neon existed and was configured at level 9 while nothing ever
       # ran it. Scope and level are explained in that file.

--- a/app/Filament/App/Pages/AccountSetup.php
+++ b/app/Filament/App/Pages/AccountSetup.php
@@ -48,12 +48,12 @@ final class AccountSetup extends Page
         $team = $this->currentTeam($resolver);
         $stored = $settings->resolve('team.setup', ['team' => $team->getKey()], [
             'completed_steps' => [],
-            'team_name' => $team->name,
+            'team_name' => (string) $team->getAttribute('name'),
             'timezone' => 'UTC',
             'integrations' => [],
         ]);
 
-        $this->teamName = (string) ($stored['team_name'] ?? $team->name);
+        $this->teamName = (string) ($stored['team_name'] ?? $team->getAttribute('name'));
         $this->timezone = (string) ($stored['timezone'] ?? 'UTC');
         $integrations = (array) ($stored['integrations'] ?? []);
         $this->githubClientId = (string) ($integrations['github_client_id'] ?? '');
@@ -70,10 +70,10 @@ final class AccountSetup extends Page
         ]);
 
         $team = $this->currentTeam($resolver);
-        abort_unless((string) $team->user_id === (string) auth()->id(), 403, 'Only the team owner can change team settings.');
+        abort_unless((string) $team->getAttribute('user_id') === (string) auth()->id(), 403, 'Only the team owner can change team settings.');
         $team->forceFill(['name' => trim($this->teamName)])->save();
-        $this->teamName = $team->name;
-        $this->persist($settings, $team, 1, ['team_name' => $team->name, 'timezone' => $this->timezone]);
+        $this->teamName = (string) $team->getAttribute('name');
+        $this->persist($settings, $team, 1, ['team_name' => $team->getAttribute('name'), 'timezone' => $this->timezone]);
         $this->step = 2;
     }
 
@@ -88,7 +88,7 @@ final class AccountSetup extends Page
         ]);
 
         $team = $this->currentTeam($resolver);
-        abort_unless((string) $team->user_id === (string) auth()->id(), 403, 'Only the team owner can change team settings.');
+        abort_unless((string) $team->getAttribute('user_id') === (string) auth()->id(), 403, 'Only the team owner can change team settings.');
         $stored = $settings->resolve('team.setup', ['team' => $team->getKey()], ['integrations' => []]);
         $integrations = (array) ($stored['integrations'] ?? []);
         $values = [
@@ -174,7 +174,7 @@ final class AccountSetup extends Page
     {
         $existing = $settings->resolve('team.setup', ['team' => $team->getKey()], [
             'completed_steps' => [],
-            'team_name' => $team->name,
+            'team_name' => (string) $team->getAttribute('name'),
             'timezone' => $this->timezone,
             'integrations' => [],
         ]);

--- a/app/Filament/App/Pages/AccountSetup.php
+++ b/app/Filament/App/Pages/AccountSetup.php
@@ -9,6 +9,7 @@ use Filament\Pages\Dashboard;
 use Filament\Pages\Page;
 use Liberu\Foundation\Organizations\Models\Team;
 use Liberu\Foundation\Organizations\Services\CurrentTeamResolver;
+use Liberu\Foundation\SessionsDevicesFilament\Pages\AccountSecurity;
 use Liberu\Foundation\Settings\Services\ScopedSettings;
 
 final class AccountSetup extends Page
@@ -17,7 +18,7 @@ final class AccountSetup extends Page
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-sparkles';
 
-    protected static string|\UnitEnum|null $navigationGroup = 'Account';
+    protected static string|\UnitEnum|null $navigationGroup = 'Getting started';
 
     protected static ?string $navigationLabel = 'Setup guide';
 
@@ -54,6 +55,9 @@ final class AccountSetup extends Page
 
         $this->teamName = (string) ($stored['team_name'] ?? $team->name);
         $this->timezone = (string) ($stored['timezone'] ?? 'UTC');
+        $integrations = (array) ($stored['integrations'] ?? []);
+        $this->githubClientId = (string) ($integrations['github_client_id'] ?? '');
+        $this->googleClientId = (string) ($integrations['google_client_id'] ?? '');
         $this->completedSteps = array_values(array_map('intval', $stored['completed_steps'] ?? []));
         $this->step = min(max((int) request()->integer('step', 1), 1), 3);
     }
@@ -84,6 +88,7 @@ final class AccountSetup extends Page
         ]);
 
         $team = $this->currentTeam($resolver);
+        abort_unless((string) $team->user_id === (string) auth()->id(), 403, 'Only the team owner can change team settings.');
         $stored = $settings->resolve('team.setup', ['team' => $team->getKey()], ['integrations' => []]);
         $integrations = (array) ($stored['integrations'] ?? []);
         $values = [
@@ -123,6 +128,11 @@ final class AccountSetup extends Page
         $this->step = $step;
     }
 
+    public function securityUrl(): string
+    {
+        return AccountSecurity::getUrl(panel: 'app');
+    }
+
     /** @return array<string, mixed> */
     public function integrationStatus(): array
     {
@@ -138,6 +148,14 @@ final class AccountSetup extends Page
             'Google OAuth' => filled($integrations['google_client_id'] ?? null) && filled($integrations['google_client_secret'] ?? null),
             'Stripe API' => filled($integrations['stripe_secret'] ?? null),
         ];
+    }
+
+    /** @return array<string, string> */
+    public function timezoneOptions(): array
+    {
+        return collect(\DateTimeZone::listIdentifiers())
+            ->mapWithKeys(fn (string $timezone): array => [$timezone => str_replace('_', ' ', $timezone)])
+            ->all();
     }
 
     private function currentTeam(CurrentTeamResolver $resolver): Team

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -9,6 +9,7 @@ use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Navigation\NavigationGroup;
 use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
@@ -40,22 +41,24 @@ class AdminPanelProvider extends PanelProvider
                 Dashboard::class,
             ])
             ->navigationGroups([
-                'Accounts & Hosting',
-                'Web Hosting',
-                'Databases',
-                'DNS',
-                'Email & Messaging',
-                'Backups',
-                'Certificates',
-                'Containers',
-                'Kubernetes',
-                'Monitoring',
-                'Server Management',
-                'Operations',
-                'Security & Compliance',
-                'Automation & Integrations',
-                'Administration',
-                'Settings',
+                NavigationGroup::make('Workspace'),
+                NavigationGroup::make('Accounts & Hosting'),
+                NavigationGroup::make('Web Hosting'),
+                NavigationGroup::make('Files & Access')->collapsed(),
+                NavigationGroup::make('Databases')->collapsed(),
+                NavigationGroup::make('DNS')->collapsed(),
+                NavigationGroup::make('Email & Messaging')->collapsed(),
+                NavigationGroup::make('Certificates')->collapsed(),
+                NavigationGroup::make('Backups')->collapsed(),
+                NavigationGroup::make('Monitoring')->collapsed(),
+                NavigationGroup::make('Automation & Integrations')->collapsed(),
+                NavigationGroup::make('Containers')->collapsed(),
+                NavigationGroup::make('Kubernetes')->collapsed(),
+                NavigationGroup::make('Server Management')->collapsed(),
+                NavigationGroup::make('Operations')->collapsed(),
+                NavigationGroup::make('Security & Compliance')->collapsed(),
+                NavigationGroup::make('Administration')->collapsed(),
+                NavigationGroup::make('Settings')->collapsed(),
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets')
             ->widgets([

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -10,6 +10,7 @@ use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Navigation\NavigationGroup;
 use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
@@ -39,9 +40,26 @@ class AppPanelProvider extends PanelProvider
                 AccountSetup::class,
             ])
             ->navigationGroups([
-                'Account',
-                'Workspace',
-                'Settings',
+                NavigationGroup::make('Getting started'),
+                NavigationGroup::make('Workspace'),
+                NavigationGroup::make('Account & Security'),
+                NavigationGroup::make('Preferences'),
+                NavigationGroup::make('Accounts & Hosting')->collapsed(),
+                NavigationGroup::make('Web Hosting')->collapsed(),
+                NavigationGroup::make('Files & Access')->collapsed(),
+                NavigationGroup::make('Databases')->collapsed(),
+                NavigationGroup::make('DNS')->collapsed(),
+                NavigationGroup::make('Email & Messaging')->collapsed(),
+                NavigationGroup::make('Certificates')->collapsed(),
+                NavigationGroup::make('Backups')->collapsed(),
+                NavigationGroup::make('Monitoring')->collapsed(),
+                NavigationGroup::make('Automation & Integrations')->collapsed(),
+                NavigationGroup::make('Containers')->collapsed(),
+                NavigationGroup::make('Kubernetes')->collapsed(),
+                NavigationGroup::make('Server Management')->collapsed(),
+                NavigationGroup::make('Operations')->collapsed(),
+                NavigationGroup::make('Security & Compliance')->collapsed(),
+                NavigationGroup::make('Administration')->collapsed(),
             ])
             ->discoverWidgets(in: app_path('Filament/App/Widgets'), for: 'App\Filament\App\Widgets')
             ->widgets([

--- a/resources/views/filament/app/pages/account-setup.blade.php
+++ b/resources/views/filament/app/pages/account-setup.blade.php
@@ -1,52 +1,53 @@
 <x-filament-panels::page>
-    <div class="mx-auto w-full max-w-5xl space-y-6">
-        <div>
-            <p class="text-sm font-medium text-primary-600">Welcome to your workspace</p>
-            <h1 class="mt-1 text-2xl font-semibold tracking-tight">Finish setting up your account</h1>
-            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">A few short steps make your team ready for daily operations. You can return here whenever you need to change an integration.</p>
-        </div>
+    <div class="mx-auto w-full max-w-5xl space-y-8">
+        <header class="rounded-2xl bg-gradient-to-br from-primary-700 to-primary-500 p-6 text-white shadow-sm md:p-8">
+            <div class="flex flex-col justify-between gap-6 md:flex-row md:items-end">
+                <div class="max-w-2xl">
+                    <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary-100">Getting started</p>
+                    <h1 class="mt-2 text-3xl font-semibold tracking-tight">Let’s get your account ready</h1>
+                    <p class="mt-3 text-sm leading-6 text-primary-50">Complete the essentials once, connect the services your project needs, then invite your team.</p>
+                </div>
+                <div class="rounded-xl bg-white/15 px-4 py-3 text-sm backdrop-blur"><span class="font-semibold">{{ count($completedSteps) }} of 3</span> steps complete</div>
+            </div>
+        </header>
 
         <nav aria-label="Setup progress" class="grid gap-3 md:grid-cols-3">
-            @foreach ([1 => 'Team profile', 2 => 'Integrations', 3 => 'Ready to go'] as $number => $label)
-                <button type="button" wire:click="goToStep({{ $number }})" @disabled($number > 1 && ! in_array($number - 1, $completedSteps, true)) class="rounded-xl border p-4 text-left transition hover:border-primary-500 disabled:cursor-not-allowed disabled:opacity-50 {{ $step === $number ? 'border-primary-500 bg-primary-50 dark:bg-primary-950/30' : 'border-gray-200 dark:border-gray-700' }}">
-                    <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Step {{ $number }}</span>
-                    <span class="mt-1 block font-medium">{{ $label }}</span>
-                    @if (in_array($number, $completedSteps, true))
-                        <span class="mt-1 block text-xs text-success-600">Complete</span>
-                    @endif
+            @foreach ([1 => ['Workspace profile', 'Name and timezone', 'heroicon-o-building-office-2'], 2 => ['Integrations', 'OAuth and API keys', 'heroicon-o-key'], 3 => ['Ready to go', 'Review and finish', 'heroicon-o-check-circle']] as $number => [$label, $description, $icon])
+                <button type="button" wire:click="goToStep({{ $number }})" @disabled($number > 1 && ! in_array($number - 1, $completedSteps, true)) class="group rounded-2xl border p-4 text-left transition hover:-translate-y-0.5 hover:border-primary-500 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50 {{ $step === $number ? 'border-primary-500 bg-primary-50 ring-1 ring-primary-500 dark:bg-primary-950/30' : 'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900' }}">
+                    <span class="flex items-center gap-3"><span class="grid size-10 shrink-0 place-items-center rounded-xl {{ $step === $number ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-500 dark:bg-gray-800' }}"><x-filament::icon :icon="$icon" class="size-5" /></span><span><span class="block text-xs font-semibold uppercase tracking-wide text-gray-500">Step {{ $number }}</span><span class="mt-1 block font-semibold text-gray-950 dark:text-white">{{ $label }}</span></span></span>
+                    <span class="mt-3 block text-sm text-gray-600 dark:text-gray-400">{{ $description }}</span>
+                    @if (in_array($number, $completedSteps, true))<span class="mt-3 block text-xs font-semibold text-success-600 dark:text-success-400">Complete</span>@endif
                 </button>
             @endforeach
         </nav>
 
-        <section class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <section class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900 md:p-8">
             @if ($step === 1)
-                <form wire:submit="saveProfile" class="space-y-6">
-                    <div><h2 class="text-lg font-semibold">Tell us about your team</h2><p class="mt-1 text-sm text-gray-600 dark:text-gray-400">This information personalises the workspace for everyone on your team.</p></div>
+                <form wire:submit="saveProfile" class="space-y-7">
+                    <div><h2 class="text-xl font-semibold text-gray-950 dark:text-white">Tell us about your team</h2><p class="mt-2 text-sm text-gray-600 dark:text-gray-400">This information personalises the workspace for everyone on your team.</p></div>
                     <div class="grid gap-5 md:grid-cols-2">
-                        <label class="block text-sm font-medium">Team name<input wire:model="teamName" required maxlength="255" class="mt-2 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800"></label>
-                        <label class="block text-sm font-medium">Workspace timezone<input wire:model="timezone" required placeholder="UTC" class="mt-2 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800"></label>
+                        <label class="block text-sm font-medium text-gray-800 dark:text-gray-200">Team name<input wire:model="teamName" required maxlength="255" class="mt-2 block w-full rounded-xl border-gray-300 bg-white px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"></label>
+                        <label class="block text-sm font-medium text-gray-800 dark:text-gray-200">Workspace timezone<select wire:model="timezone" required class="mt-2 block w-full rounded-xl border-gray-300 bg-white px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800">@foreach ($this->timezoneOptions() as $value => $label)<option value="{{ $value }}">{{ $label }}</option>@endforeach</select></label>
                     </div>
                     @error('teamName')<p class="text-sm text-danger-600">{{ $message }}</p>@enderror
                     @error('timezone')<p class="text-sm text-danger-600">{{ $message }}</p>@enderror
-                    <button type="submit" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500" wire:loading.attr="disabled">Save and continue</button>
+                    <button type="submit" class="rounded-xl bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-500" wire:loading.attr="disabled">Save and continue <span aria-hidden="true">→</span></button>
                 </form>
             @elseif ($step === 2)
-                <form wire:submit="saveIntegrations" class="space-y-6">
-                    <div><h2 class="text-lg font-semibold">Connect the services you use</h2><p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Credentials are encrypted before storage and are never shown again after saving. Leave a provider blank if you do not use it.</p></div>
-                    <div class="grid gap-5 md:grid-cols-2">
-                        <label class="block text-sm font-medium">GitHub OAuth client ID<input wire:model="githubClientId" maxlength="255" class="mt-2 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800"></label>
-                        <label class="block text-sm font-medium">GitHub OAuth client secret<input wire:model="githubClientSecret" type="password" maxlength="1000" autocomplete="new-password" class="mt-2 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800"></label>
-                        <label class="block text-sm font-medium">Google OAuth client ID<input wire:model="googleClientId" maxlength="255" class="mt-2 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800"></label>
-                        <label class="block text-sm font-medium">Google OAuth client secret<input wire:model="googleClientSecret" type="password" maxlength="1000" autocomplete="new-password" class="mt-2 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800"></label>
-                        <label class="block text-sm font-medium md:col-span-2">Stripe secret key<input wire:model="stripeSecret" type="password" maxlength="1000" autocomplete="new-password" class="mt-2 block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800"></label>
+                <form wire:submit="saveIntegrations" class="space-y-7">
+                    <div><h2 class="text-xl font-semibold text-gray-950 dark:text-white">Connect the services your project needs</h2><p class="mt-2 text-sm text-gray-600 dark:text-gray-400">Configure OAuth providers for social sign-in and API credentials for billing or automation. Secrets are encrypted before storage and never shown again.</p></div>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div class="rounded-xl border border-gray-200 p-4 dark:border-gray-700"><div class="mb-4 flex items-center justify-between gap-3"><span class="font-semibold">GitHub OAuth</span><span class="text-xs {{ ($this->integrationStatus()['GitHub OAuth'] ?? false) ? 'text-success-600' : 'text-gray-500' }}">{{ ($this->integrationStatus()['GitHub OAuth'] ?? false) ? 'Configured' : 'Optional' }}</span></div><div class="space-y-3"><input wire:model="githubClientId" placeholder="Client ID" aria-label="GitHub OAuth client ID" maxlength="255" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"><input wire:model="githubClientSecret" type="password" placeholder="Client secret" aria-label="GitHub OAuth client secret" maxlength="1000" autocomplete="new-password" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"></div></div>
+                        <div class="rounded-xl border border-gray-200 p-4 dark:border-gray-700"><div class="mb-4 flex items-center justify-between gap-3"><span class="font-semibold">Google OAuth</span><span class="text-xs {{ ($this->integrationStatus()['Google OAuth'] ?? false) ? 'text-success-600' : 'text-gray-500' }}">{{ ($this->integrationStatus()['Google OAuth'] ?? false) ? 'Configured' : 'Optional' }}</span></div><div class="space-y-3"><input wire:model="googleClientId" placeholder="Client ID" aria-label="Google OAuth client ID" maxlength="255" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"><input wire:model="googleClientSecret" type="password" placeholder="Client secret" aria-label="Google OAuth client secret" maxlength="1000" autocomplete="new-password" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"></div></div>
+                        <div class="rounded-xl border border-gray-200 p-4 dark:border-gray-700 md:col-span-2"><div class="mb-4 flex items-center justify-between gap-3"><span class="font-semibold">Stripe API</span><span class="text-xs {{ ($this->integrationStatus()['Stripe API'] ?? false) ? 'text-success-600' : 'text-gray-500' }}">{{ ($this->integrationStatus()['Stripe API'] ?? false) ? 'Configured' : 'Optional' }}</span></div><input wire:model="stripeSecret" type="password" placeholder="Secret key (sk_live_… or sk_test_…)" aria-label="Stripe secret key" maxlength="1000" autocomplete="new-password" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"></div>
                     </div>
-                    <div class="rounded-lg bg-gray-50 p-4 text-sm dark:bg-gray-800"><span class="font-medium">Current status</span><dl class="mt-2 grid gap-1 md:grid-cols-3">@foreach ($this->integrationStatus() as $name => $configured)<div><dt class="inline">{{ $name }}:</dt> <dd class="inline">{{ $configured ? 'Configured' : 'Not configured' }}</dd></div>@endforeach</dl></div>
-                    <div class="flex gap-3"><button type="button" wire:click="goToStep(1)" class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold dark:border-gray-600">Back</button><button type="submit" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500" wire:loading.attr="disabled">Save and continue</button></div>
+                    <div class="rounded-xl bg-gray-50 p-4 text-sm text-gray-600 dark:bg-gray-800/70 dark:text-gray-300"><span class="font-semibold text-gray-900 dark:text-white">No credentials yet?</span> Leave fields blank to skip them. You can update integrations later, and create personal API tokens from <a href="{{ $this->securityUrl() }}" class="font-semibold text-primary-600 hover:underline dark:text-primary-400">Account security</a>.</div>
+                    <div class="flex gap-3"><button type="button" wire:click="goToStep(1)" class="rounded-xl border border-gray-300 px-5 py-2.5 text-sm font-semibold dark:border-gray-600">Back</button><button type="submit" class="rounded-xl bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-primary-500" wire:loading.attr="disabled">Save and continue <span aria-hidden="true">→</span></button></div>
                 </form>
             @else
-                <div class="space-y-6"><div><h2 class="text-lg font-semibold">Your workspace is ready</h2><p class="mt-1 text-sm text-gray-600 dark:text-gray-400">You can manage team members, security, and integrations from the Account menu at any time.</p></div><div class="rounded-lg bg-success-50 p-4 text-sm text-success-800 dark:bg-success-950/30 dark:text-success-200">Setup is complete for <strong>{{ $teamName }}</strong>.</div><div class="flex gap-3"><button type="button" wire:click="goToStep(2)" class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold dark:border-gray-600">Review integrations</button><button type="button" wire:click="finish" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500" wire:loading.attr="disabled">Go to dashboard</button></div></div>
+                <div class="space-y-7"><div><h2 class="text-xl font-semibold text-gray-950 dark:text-white">Your workspace is ready</h2><p class="mt-2 text-sm text-gray-600 dark:text-gray-400">The essentials for <strong>{{ $teamName }}</strong> are saved. Use this quick checklist before you start managing infrastructure.</p></div><div class="grid gap-3 sm:grid-cols-3"><div class="rounded-xl bg-success-50 p-4 text-sm text-success-800 dark:bg-success-950/30 dark:text-success-200"><x-filament::icon icon="heroicon-o-check-circle" class="mb-2 size-5" /><p class="font-semibold">Workspace profile</p><p class="mt-1 text-xs">Name and timezone saved.</p></div><div class="rounded-xl bg-success-50 p-4 text-sm text-success-800 dark:bg-success-950/30 dark:text-success-200"><x-filament::icon icon="heroicon-o-check-circle" class="mb-2 size-5" /><p class="font-semibold">Integrations</p><p class="mt-1 text-xs">Credentials saved securely.</p></div><div class="rounded-xl bg-gray-50 p-4 text-sm text-gray-700 dark:bg-gray-800/70 dark:text-gray-300"><x-filament::icon icon="heroicon-o-key" class="mb-2 size-5" /><p class="font-semibold">API access</p><p class="mt-1 text-xs">Create a token when automation is ready.</p></div></div><div class="flex flex-wrap gap-3"><button type="button" wire:click="goToStep(2)" class="rounded-xl border border-gray-300 px-5 py-2.5 text-sm font-semibold dark:border-gray-600">Review integrations</button><a href="{{ $this->securityUrl() }}" class="rounded-xl border border-gray-300 px-5 py-2.5 text-sm font-semibold dark:border-gray-600">Manage API access</a><button type="button" wire:click="finish" class="rounded-xl bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-primary-500" wire:loading.attr="disabled">Go to dashboard <span aria-hidden="true">→</span></button></div></div>
             @endif
-            <p wire:loading role="status" class="text-sm text-gray-500">Saving your setup…</p>
+            <p wire:loading role="status" class="mt-5 text-sm text-gray-500">Saving your setup…</p>
         </section>
     </div>
 </x-filament-panels::page>


### PR DESCRIPTION
## Summary
- organize app and admin panel navigation into logical collapsible groups
- move account setup into Getting started
- improve the onboarding wizard for team profile, OAuth/API credentials, and API access handoff

## Verification
- php artisan test tests/Feature/AccountSetupTest.php tests/Feature/AdminPanelRendersTest.php tests/Feature/AdminPanelAccessTest.php
- vendor/bin/pint
- git diff --check