### PR TITLE
Add team-scoped website operations overview

### DIFF
--- a/app/Filament/App/Pages/Websites.php
+++ b/app/Filament/App/Pages/Websites.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Filament\App\Pages;
+
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Pages\Page;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Liberu\ControlPanel\WebHosting\Enums\DomainStatus;
+use Liberu\ControlPanel\WebHosting\Models\Domain;
+use Liberu\ControlPanel\WebHosting\Models\SslCertificate;
+use Liberu\ControlPanel\WebHosting\WebHostingServiceProvider;
+use Liberu\ControlPanel\WebHostingFilament\Resources\DomainResource;
+use Liberu\Foundation\Organizations\Models\Team;
+use Liberu\Foundation\Organizations\Services\CurrentTeamResolver;
+
+class Websites extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-globe-alt';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Web Hosting';
+
+    protected static ?int $navigationSort = -10;
+
+    protected string $view = 'filament.pages.websites';
+
+    protected ?bool $canManageWebsites = null;
+
+    public static function canAccess(): bool
+    {
+        return auth()->check()
+            && app()->providerIsLoaded(WebHostingServiceProvider::class)
+            && static::currentTeam() !== null
+            && DomainResource::canViewAny();
+    }
+
+    protected static function currentTeam(): ?Team
+    {
+        $user = auth()->user();
+
+        if ($user === null) {
+            return null;
+        }
+
+        $teamId = Filament::getCurrentPanel()?->getId() === 'admin'
+            ? Filament::getTenant()?->getKey()
+            : $user->current_team_id;
+
+        return app(CurrentTeamResolver::class)->resolve($user, $teamId);
+    }
+
+    public function getSubheading(): string
+    {
+        return 'Review hosting configuration, certificate expiry and deployment failures for your active team. These records do not verify live website availability.';
+    }
+
+    /** @return Builder<Domain> */
+    protected function websitesQuery(): Builder
+    {
+        abort_unless(static::canAccess(), 403);
+        $teamId = (string) static::currentTeam()->getKey();
+
+        return Domain::query()
+            ->where('team_id', $teamId)
+            ->select(['id', 'team_id', 'account_id', 'hostname', 'status', 'created_at'])
+            ->withCount([
+                'virtualHosts as active_hosts_count' => fn (Builder $query) => $query->where('active', true),
+                'gitDeployments as failed_deployments_count' => fn (Builder $query) => $query->where('team_id', $teamId)->where('status', 'failed'),
+            ])
+            ->addSelect(['certificate_expires_at' => SslCertificate::query()
+                ->selectRaw('MAX(expires_at)')
+                ->whereColumn('domain_id', 'control_panel_domains.id')
+                ->where('team_id', $teamId)
+                ->where('status', 'issued')]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => $this->websitesQuery())
+            ->columns([
+                TextColumn::make('hostname')->label('Website')->searchable()->sortable()->wrap(),
+                TextColumn::make('status')->badge()
+                    ->formatStateUsing(fn (DomainStatus $state): string => ucfirst($state->value))
+                    ->color(fn (DomainStatus $state): string => match ($state) {
+                        DomainStatus::Active => 'success',
+                        DomainStatus::Suspended => 'danger',
+                        default => 'gray',
+                    }),
+                TextColumn::make('active_hosts_count')->label('Active host configurations')->numeric()->sortable(),
+                TextColumn::make('certificate_expires_at')->label('Issued certificate expires')->dateTime()->sortable()
+                    ->placeholder('Not recorded'),
+                TextColumn::make('certificate_guidance')->label('Certificate guidance')->wrap()
+                    ->state(fn (Domain $record): string => $this->certificateSummary($record)),
+                TextColumn::make('failed_deployments_count')->label('Failed deployments')->numeric()->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')->options(collect(DomainStatus::cases())->mapWithKeys(
+                    fn (DomainStatus $status): array => [$status->value => ucfirst($status->value)],
+                )->all()),
+                Filter::make('needs_attention')->label('Needs attention')->query(function (Builder $query): Builder {
+                    $teamId = (string) static::currentTeam()?->getKey();
+
+                    return $query->where(fn (Builder $query) => $query
+                        ->where('status', '!=', DomainStatus::Active->value)
+                        ->orWhereDoesntHave('virtualHosts', fn (Builder $hosts) => $hosts->where('active', true))
+                        ->orWhereHas('gitDeployments', fn (Builder $deployments) => $deployments->where('team_id', $teamId)->where('status', 'failed'))
+                        ->orWhereNotIn('id', SslCertificate::query()->select('domain_id')
+                            ->where('team_id', $teamId)->where('status', 'issued')->where('expires_at', '>', now()->addDays(30))));
+                }),
+            ])
+            ->recordActions([
+                Action::make('manage')->label('Manage website')->icon('heroicon-o-pencil-square')
+                    ->visible(fn (Domain $record): bool => $this->canManageWebsites() && DomainResource::canEdit($record))
+                    ->url(fn (Domain $record): ?string => $this->canManageWebsites()
+                        ? DomainResource::getUrl('edit', ['record' => $record]) : null),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->paginationPageOptions([10, 25, 50])
+            ->emptyStateHeading('No websites found')
+            ->emptyStateDescription('Add a domain to start hosting, or clear your search and filters. If you cannot add domains, ask your team administrator.')
+            ->emptyStateIcon('heroicon-o-globe-alt');
+    }
+
+    protected function certificateSummary(Domain $record): string
+    {
+        $expiry = $record->getAttribute('certificate_expires_at');
+
+        return match (true) {
+            $expiry === null => 'Request or record an issued certificate.',
+            $expiry <= now()->toDateTimeString() => 'Expired — renew the certificate.',
+            $expiry <= now()->addDays(30)->toDateTimeString() => 'Expires within 30 days — check renewal.',
+            default => 'Expiry recorded; deployment and auto-renewal are not verified.',
+        };
+    }
+
+    protected function canManageWebsites(): bool
+    {
+        return $this->canManageWebsites ??= in_array(DomainResource::class, Filament::getCurrentPanel()?->getResources() ?? [], true)
+            && (string) auth()->user()?->current_team_id === (string) static::currentTeam()?->getKey();
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('addWebsite')->label('Add website')->icon('heroicon-o-plus')
+                ->visible(fn (): bool => $this->canManageWebsites() && DomainResource::canCreate())
+                ->url(fn (): ?string => $this->canManageWebsites() ? DomainResource::getUrl('create') : null),
+        ];
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\App\Pages\Websites;
 use App\Filament\ModulePlugins;
 use App\Support\ThemeColors;
 use BezhanSalleh\FilamentShield\Middleware\SyncShieldTenant;
@@ -39,6 +40,7 @@ class AdminPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\Filament\Pages')
             ->pages([
                 Dashboard::class,
+                Websites::class,
             ])
             ->navigationGroups([
                 NavigationGroup::make('Workspace'),

--- a/docs/HOSTING_PRODUCT_ROADMAP.md
+++ b/docs/HOSTING_PRODUCT_ROADMAP.md
@@ -1,0 +1,45 @@
+# Hosting control panel: workflow and parity roadmap
+
+## Scope and evidence
+
+This is a delivery plan, not a claim that the application already matches or exceeds every competing panel. Installed models, API endpoints and resource screens establish implementation surfaces; they do not prove that remote provisioning, recovery or failover works.
+
+The reference baseline was reviewed on 2026-09-06:
+
+- [cPanel/WHM features](https://www.cpanel.net/products/cpanel-whm-features/) establish customer hosting tools, provider account/package management, backups and databases as baseline workflows.
+- [Plesk features](https://www.plesk.com/features/) and [WP Toolkit](https://www.plesk.com/wp-toolkit/) emphasize a consolidated site dashboard, staging, cloning, updates, monitoring and recovery.
+- [DirectAdmin backup, restore and migration](https://docs.directadmin.com/directadmin/backup-restore-migration/index.html) covers account archives containing websites, databases and email, with separate user, reseller and administrator interfaces.
+- [Virtualmin navigation](https://www.virtualmin.com/docs/getting-started/how-to-navigate-in-virtualmin/) distinguishes domain-owner and administrator workflows and documents migration tools.
+- [KubePanel architecture](https://kubepanel.io/documentation/) and [workloads](https://kubepanel.io/features/multi-workload/) provide the reference for per-site container isolation and Kubernetes-backed hosting. Its workload page labels Node.js as coming soon; advertised runtime flexibility is not evidence that every workload is production-ready.
+
+## Delivered increment: Websites overview
+
+`Web Hosting → Websites` is registered in both panels. It appears only when the web-hosting provider is enabled and the actor has an active, accessible team and domain-list permission. The app panel uses the current team; the admin panel uses its selected tenant.
+
+- Search hostnames, filter lifecycle status, paginate and sort.
+- Review active virtual-host configuration counts, issued-certificate expiry and failed deployment counts together.
+- Filter sites needing attention: non-active lifecycle, no active host configuration, failed deployment, or no issued certificate valid beyond 30 days.
+- Ignore revoked certificates and cross-team certificate/deployment records when computing these indicators.
+- Show management links only when the resource is registered in the current panel, its policy allows the operation and its current-team scoping agrees with the selected team.
+- Use database aggregates instead of loading secrets or querying relationships once per website.
+
+These are configuration indicators, not uptime probes. The overview does not assert that a certificate is installed, that renewal works, or that a backup is recoverable. Customer accounts without the management resource get a read-only overview; adding a domain still requires their team administrator. No module is forcibly enabled by this change.
+
+## Prioritized delivery backlog
+
+| Priority | Workflow | Existing surface to build on | Acceptance gate |
+| --- | --- | --- | --- |
+| P0 | Secure onboarding and connection readiness | Account setup, scoped settings, connected accounts, node credentials | Team owners authorize changes; stored credentials are distinguished from tested connections; reconnect, expiry and revoked-access paths are tested; no secret appears in client state or logs. |
+| P0 | Launch a website | Accounts, domains, virtual hosts, runtime, DNS and certificate modules | One resumable workflow produces a functioning test site; prerequisites are checked before mutation; retries are idempotent; failures identify the failed stage and safe recovery action. |
+| P0 | Backup and verified restore | Backup destinations, schedules, executions and restores | A disposable-site restore verifies file checksums and database content; destructive replacement requires explicit confirmation; retention and remote-storage failures are visible. |
+| P1 | Website workspace | Websites overview, hosting resources, file/database/mail/DNS modules | Site-scoped tools preserve team context and role permissions; non-admin customers can complete allowed tasks without raw identifiers; keyboard, mobile and dark-mode browser tests pass. |
+| P1 | WordPress lifecycle | Hosted applications, update checks, Git deployment | Install, clone to staging, back up, update and roll back on an isolated test host; failed updates cannot silently replace a working site. |
+| P1 | Migration assistant | Account, file, mail, database and DNS modules | Import representative cPanel, Plesk, DirectAdmin and Virtualmin archives using dry-run mapping, quota checks, safe archive extraction, progress and post-import reconciliation. Do not change public DNS without confirmation. |
+| P1 | Mail deliverability and DNS diagnostics | Mail diagnostics, DKIM, zones, DNSSEC and propagation | Show authoritative DNS results, SPF/DKIM/DMARC problems, mail delivery traces and timestamped remediation guidance; enforce tenant scope and outbound request restrictions. |
+| P1 | Reseller and delegated hosting | Hosting packages, account delegation and teams | Enforce quotas and delegated permissions on both API and UI operations; test suspension, renewal and billing retries with provider sandboxes. |
+| P2 | Container and Kubernetes operations | Workloads, networks, secrets, clusters, ingress and autoscaling | Prove resource isolation, network policy, deployment readiness, rollback and node-failure recovery on disposable infrastructure. |
+| P2 | Fleet health and remediation | Monitoring, incidents, OS adapters and automation | Correlate timestamped observed health with configuration; proposed remediation includes scope and risk; retries and audit trails are tested. |
+
+## Release standard
+
+Each increment needs policy and cross-team tests, bounded queries, reproducible locked dependency installation, formatting/static analysis, and the full test suite. Infrastructure features additionally require disposable-host or cluster integration tests; record-only tests are insufficient. Browser validation must cover the assembled panels before describing the UX as fully verified. Publish a major release only after upgrade PRs and the integrated main branch pass their required checks.

--- a/resources/views/filament/pages/websites.blade.php
+++ b/resources/views/filament/pages/websites.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/tests/Feature/WebsitesTest.php
+++ b/tests/Feature/WebsitesTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Filament\App\Pages\Websites;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Liberu\ControlPanel\WebHosting\Models\Domain;
+use Liberu\ControlPanel\WebHosting\Models\GitDeployment;
+use Liberu\ControlPanel\WebHosting\Models\SslCertificate;
+use Liberu\ControlPanel\WebHosting\WebHostingServiceProvider;
+use Liberu\ControlPanel\WebHostingFilament\Resources\DomainResource;
+use Liberu\Foundation\Organizations\Models\Team;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    app()->register(WebHostingServiceProvider::class);
+    $this->artisan('migrate');
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+    Filament::setTenant(null);
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create(['user_id' => $this->user->getKey()]);
+    $this->user->forceFill(['current_team_id' => $this->team->getKey()])->save();
+    $this->actingAs($this->user);
+});
+
+function websiteForTeam(Team $team, string $hostname = 'example.test'): Domain
+{
+    return Domain::query()->create(['team_id' => $team->getKey(), 'hostname' => $hostname, 'status' => 'active']);
+}
+
+it('shows only the current team websites and supports searching', function (): void {
+    $mine = websiteForTeam($this->team);
+    $other = websiteForTeam(Team::factory()->create(), 'private.test');
+    $another = websiteForTeam($this->team, 'another.test');
+
+    Livewire::test(Websites::class)
+        ->assertCanSeeTableRecords([$mine, $another])
+        ->assertCanNotSeeTableRecords([$other])
+        ->searchTable('example.test')
+        ->assertCanSeeTableRecords([$mine])
+        ->assertCanNotSeeTableRecords([$another, $other]);
+});
+
+it('shows certificate guidance without treating a stored record as live health', function (?string $expiry, string $status, string $message): void {
+    $domain = websiteForTeam($this->team);
+    SslCertificate::query()->create([
+        'team_id' => $this->team->getKey(), 'domain_id' => $domain->getKey(),
+        'issuer' => 'test', 'status' => $status,
+        'expires_at' => $expiry === null ? null : now()->modify($expiry),
+    ]);
+
+    Livewire::test(Websites::class)->assertSee($message);
+})->with([
+    [null, 'issued', 'Request or record an issued certificate.'],
+    ['-1 day', 'issued', 'Expired — renew the certificate.'],
+    ['+10 days', 'issued', 'Expires within 30 days — check renewal.'],
+    ['+60 days', 'issued', 'Expiry recorded; deployment and auto-renewal are not verified.'],
+    ['+60 days', 'revoked', 'Request or record an issued certificate.'],
+]);
+
+it('filters sites needing attention using configuration, expiry and deployment state', function (): void {
+    $ready = websiteForTeam($this->team, 'configured.test');
+    $ready->virtualHosts()->create(['server' => 'nginx', 'document_root' => '/srv/site', 'active' => true]);
+    SslCertificate::query()->create([
+        'team_id' => $this->team->getKey(), 'domain_id' => $ready->getKey(),
+        'issuer' => 'test', 'status' => 'issued', 'expires_at' => now()->addDays(60),
+    ]);
+    $pending = websiteForTeam($this->team, 'pending.test');
+    $pending->update(['status' => 'pending']);
+
+    Livewire::test(Websites::class)->filterTable('needs_attention')
+        ->assertCanSeeTableRecords([$pending])->assertCanNotSeeTableRecords([$ready]);
+
+    GitDeployment::query()->create([
+        'team_id' => $this->team->getKey(), 'domain_id' => $ready->getKey(),
+        'repository_url' => 'https://example.test/repo.git', 'repository_type' => 'other',
+        'deploy_path' => '/srv/site', 'status' => 'failed',
+    ]);
+    Livewire::test(Websites::class)->filterTable('needs_attention')->assertCanSeeTableRecords([$ready, $pending]);
+    Livewire::test(Websites::class)->filterTable('status', 'pending')->assertCanSeeTableRecords([$pending])->assertCanNotSeeTableRecords([$ready]);
+});
+
+it('does not use a foreign team certificate to clear an alert', function (): void {
+    $domain = websiteForTeam($this->team);
+    SslCertificate::query()->create([
+        'team_id' => Team::factory()->create()->getKey(), 'domain_id' => $domain->getKey(),
+        'issuer' => 'test', 'status' => 'issued', 'expires_at' => now()->addDays(60),
+    ]);
+    Livewire::test(Websites::class)->assertSee('Request or record an issued certificate.')
+        ->filterTable('needs_attention')->assertCanSeeTableRecords([$domain]);
+});
+
+it('rejects a forged or missing current team', function (bool $missing): void {
+    $this->user->forceFill(['current_team_id' => $missing ? null : Team::factory()->create()->getKey()])->save();
+    Livewire::test(Websites::class)->assertForbidden();
+})->with([true, false]);
+
+it('rechecks membership on subsequent requests', function (): void {
+    $component = Livewire::test(Websites::class);
+    $this->team->update(['status' => 'inactive']);
+    $component->call('$refresh')->assertForbidden();
+});
+
+it('respects the domain view policy', function (): void {
+    Gate::before(fn (): bool => false);
+    Livewire::test(Websites::class)->assertForbidden();
+});
+
+it('uses the admin tenant instead of the user current team', function (): void {
+    $current = websiteForTeam($this->team);
+    $selected = Team::factory()->create(['user_id' => $this->user->getKey()]);
+    $domain = websiteForTeam($selected, 'selected.test');
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    Filament::setTenant($selected);
+
+    Livewire::test(Websites::class)->assertCanSeeTableRecords([$domain])->assertCanNotSeeTableRecords([$current]);
+});
+
+it('has a bounded query count as website rows grow', function (): void {
+    websiteForTeam($this->team);
+    Livewire::test(Websites::class);
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+    Livewire::test(Websites::class);
+    $singleCount = count(DB::getQueryLog());
+    DB::disableQueryLog();
+    foreach (range(1, 9) as $index) {
+        websiteForTeam($this->team, "site-{$index}.test");
+    }
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+    Livewire::test(Websites::class);
+    $multipleCount = count(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    expect($multipleCount)->toBeLessThanOrEqual($singleCount);
+});
+
+it('hides management actions when the app has no domain management resource', function (): void {
+    $domain = websiteForTeam($this->team);
+    Livewire::test(Websites::class)->assertActionHidden('addWebsite')
+        ->assertTableActionHidden('manage', $domain);
+});
+
+it('offers policy-aware management links when the resource and team context agree', function (): void {
+    $domain = websiteForTeam($this->team);
+    $panel = Filament::getPanel('admin');
+    $panel->resources([DomainResource::class]);
+    Filament::setCurrentPanel($panel);
+    Filament::setTenant($this->team);
+    Route::get('/admin/{tenant}/domains/create', fn () => 'create')->name('filament.admin.resources.domains.create');
+    Route::get('/admin/{tenant}/domains/{record}/edit', fn () => 'edit')->name('filament.admin.resources.domains.edit');
+
+    Livewire::test(Websites::class)->assertActionVisible('addWebsite')
+        ->assertTableActionVisible('manage', $domain)
+        ->assertSee(DomainResource::getUrl('edit', ['record' => $domain]));
+});
+
+it('requires authentication', function (): void {
+    auth()->logout();
+    expect(Websites::canAccess())->toBeFalse();
+    Livewire::test(Websites::class)->assertForbidden();
+});


### PR DESCRIPTION
Adds a shared Websites overview to the app and admin panels when the hosting module is enabled. Includes hostname search, lifecycle and needs-attention filters, virtual-host counts, certificate expiry guidance, failed-deployment counts, and policy-aware management links. Team ownership and membership are checked on every request; the admin view uses the selected tenant. Uses existing Filament components and aggregate queries. Adds a source-backed hosting parity roadmap without claiming live infrastructure verification or full competitor parity. Validation: full local suite 523 passed / 12 existing skips; latest focused suite 17 passed; PHPStan, Pint and asset build passed. Browser and Lerd live-route profiling were not available. Dependency upgrades and major release remain separate outstanding work.