### PR TITLE
Secure account setup and clarify hosting readiness

### DIFF
--- a/app/Filament/App/Pages/AccountSetup.php
+++ b/app/Filament/App/Pages/AccountSetup.php
@@ -7,10 +7,14 @@ namespace App\Filament\App\Pages;
 use App\Settings\TeamSetupDefinition;
 use Filament\Pages\Dashboard;
 use Filament\Pages\Page;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Liberu\Foundation\Organizations\Models\Team;
 use Liberu\Foundation\Organizations\Services\CurrentTeamResolver;
 use Liberu\Foundation\SessionsDevicesFilament\Pages\AccountSecurity;
 use Liberu\Foundation\Settings\Services\ScopedSettings;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 
 final class AccountSetup extends Page
 {
@@ -24,7 +28,14 @@ final class AccountSetup extends Page
 
     protected static ?int $navigationSort = 1;
 
+    #[Locked]
     public int $step = 1;
+
+    #[Locked]
+    public string $teamId = '';
+
+    #[Locked]
+    public int $revision = 0;
 
     public string $teamName = '';
 
@@ -41,11 +52,21 @@ final class AccountSetup extends Page
     public string $stripeSecret = '';
 
     /** @var list<int> */
+    #[Locked]
     public array $completedSteps = [];
+
+    public static function canAccess(): bool
+    {
+        $user = auth()->user();
+        $team = $user === null ? null : app(CurrentTeamResolver::class)->resolve($user, $user->current_team_id);
+
+        return $team !== null && (string) $team->getAttribute('user_id') === (string) auth()->id();
+    }
 
     public function mount(CurrentTeamResolver $resolver, ScopedSettings $settings): void
     {
         $team = $this->currentTeam($resolver);
+        $this->teamId = (string) $team->getKey();
         $stored = $settings->resolve('team.setup', ['team' => $team->getKey()], [
             'completed_steps' => [],
             'team_name' => (string) $team->getAttribute('name'),
@@ -59,26 +80,33 @@ final class AccountSetup extends Page
         $this->githubClientId = (string) ($integrations['github_client_id'] ?? '');
         $this->googleClientId = (string) ($integrations['google_client_id'] ?? '');
         $this->completedSteps = array_values(array_map('intval', $stored['completed_steps'] ?? []));
-        $this->step = min(max((int) request()->integer('step', 1), 1), 3);
+        $this->revision = (int) ($stored['revision'] ?? 0);
+        $nextStep = ! in_array(1, $this->completedSteps, true) ? 1 : (! in_array(2, $this->completedSteps, true) ? 2 : 3);
+        $this->step = min(max(request()->integer('step', $nextStep), 1), $nextStep);
+    }
+
+    public function hydrate(CurrentTeamResolver $resolver): void
+    {
+        $this->currentTeam($resolver);
     }
 
     public function saveProfile(ScopedSettings $settings, CurrentTeamResolver $resolver): void
     {
+        $team = $this->currentTeam($resolver);
+        $this->teamName = trim($this->teamName);
         $this->validate([
             'teamName' => ['required', 'string', 'max:255'],
             'timezone' => ['required', 'timezone'],
         ]);
 
-        $team = $this->currentTeam($resolver);
-        abort_unless((string) $team->getAttribute('user_id') === (string) auth()->id(), 403, 'Only the team owner can change team settings.');
-        $team->forceFill(['name' => trim($this->teamName)])->save();
-        $this->teamName = (string) $team->getAttribute('name');
-        $this->persist($settings, $team, 1, ['team_name' => $team->getAttribute('name'), 'timezone' => $this->timezone]);
+        $this->persist($settings, $team, 1, ['team_name' => $this->teamName, 'timezone' => $this->timezone]);
         $this->step = 2;
     }
 
     public function saveIntegrations(ScopedSettings $settings, CurrentTeamResolver $resolver): void
     {
+        $team = $this->currentTeam($resolver);
+        $this->requireSteps($settings, $team, [1]);
         $this->validate([
             'githubClientId' => ['nullable', 'string', 'max:255'],
             'githubClientSecret' => ['nullable', 'string', 'max:1000'],
@@ -87,8 +115,6 @@ final class AccountSetup extends Page
             'stripeSecret' => ['nullable', 'string', 'max:1000'],
         ]);
 
-        $team = $this->currentTeam($resolver);
-        abort_unless((string) $team->getAttribute('user_id') === (string) auth()->id(), 403, 'Only the team owner can change team settings.');
         $stored = $settings->resolve('team.setup', ['team' => $team->getKey()], ['integrations' => []]);
         $integrations = (array) ($stored['integrations'] ?? []);
         $values = [
@@ -105,6 +131,17 @@ final class AccountSetup extends Page
             }
         }
 
+        foreach (['github' => 'githubClientSecret', 'google' => 'googleClientSecret'] as $provider => $secretField) {
+            $id = $integrations[$provider.'_client_id'] ?? '';
+            $secret = $integrations[$provider.'_client_secret'] ?? '';
+            if (filled($id) !== filled($secret)) {
+                throw ValidationException::withMessages([$secretField => 'Provide both the client ID and client secret, or leave both blank.']);
+            }
+            if (filled($id) && $id !== ($stored['integrations'][$provider.'_client_id'] ?? '') && blank($this->{$secretField})) {
+                throw ValidationException::withMessages([$secretField => 'Enter a new secret when changing the client ID.']);
+            }
+        }
+
         $this->persist($settings, $team, 2, ['integrations' => $integrations]);
         $this->githubClientSecret = '';
         $this->googleClientSecret = '';
@@ -115,14 +152,24 @@ final class AccountSetup extends Page
     public function finish(ScopedSettings $settings, CurrentTeamResolver $resolver): void
     {
         $team = $this->currentTeam($resolver);
+        $this->requireSteps($settings, $team, [1, 2]);
         $this->persist($settings, $team, 3, []);
         $this->redirect(Dashboard::getUrl(panel: 'app'));
     }
 
-    public function goToStep(int $step): void
+    public function goToStep(int $step, ScopedSettings $settings, CurrentTeamResolver $resolver): void
     {
-        if ($step < 1 || $step > 3 || ($step > 1 && ! in_array($step - 1, $this->completedSteps, true))) {
+        $team = $this->currentTeam($resolver);
+        if ($step < 1 || $step > 3) {
             return;
+        }
+
+        $this->requireSteps($settings, $team, $step === 1 ? [] : range(1, $step - 1));
+
+        if ($step === 3) {
+            $stored = $settings->resolve('team.setup', ['team' => $team->getKey()]);
+            $this->teamName = (string) ($stored['team_name'] ?? $team->getAttribute('name'));
+            $this->timezone = (string) ($stored['timezone'] ?? 'UTC');
         }
 
         $this->step = $step;
@@ -134,14 +181,11 @@ final class AccountSetup extends Page
     }
 
     /** @return array<string, mixed> */
+    #[Computed]
     public function integrationStatus(): array
     {
-        $teamId = auth()->user()?->current_team_id;
-        if ($teamId === null) {
-            return [];
-        }
-
-        $integrations = app(ScopedSettings::class)->resolve('team.setup', ['team' => $teamId], ['integrations' => []])['integrations'] ?? [];
+        $team = $this->currentTeam(app(CurrentTeamResolver::class));
+        $integrations = app(ScopedSettings::class)->resolve('team.setup', ['team' => $team->getKey()], ['integrations' => []])['integrations'] ?? [];
 
         return [
             'GitHub OAuth' => filled($integrations['github_client_id'] ?? null) && filled($integrations['github_client_secret'] ?? null),
@@ -165,6 +209,8 @@ final class AccountSetup extends Page
         $team = $resolver->resolve($user, $user->current_team_id);
 
         abort_if($team === null, 403, 'Choose an active team before opening setup.');
+        abort_unless((string) $team->getAttribute('user_id') === (string) $user->getAuthIdentifier(), 403, 'Only the team owner can manage setup.');
+        abort_if($this->teamId !== '' && $this->teamId !== (string) $team->getKey(), 409, 'Your active team changed. Reload setup before saving.');
 
         return $team;
     }
@@ -172,14 +218,34 @@ final class AccountSetup extends Page
     /** @param array<string, mixed> $changes */
     private function persist(ScopedSettings $settings, Team $team, int $step, array $changes): void
     {
-        $existing = $settings->resolve('team.setup', ['team' => $team->getKey()], [
-            'completed_steps' => [],
-            'team_name' => (string) $team->getAttribute('name'),
-            'timezone' => $this->timezone,
-            'integrations' => [],
-        ]);
-        $completed = array_values(array_unique([...array_map('intval', $existing['completed_steps'] ?? []), $step]));
-        $settings->put(new TeamSetupDefinition(), 'team', (string) $team->getKey(), array_replace_recursive($existing, $changes, ['completed_steps' => $completed]));
-        $this->completedSteps = $completed;
+        DB::transaction(function () use ($settings, $team, $step, $changes): void {
+            $lockedTeam = Team::query()->whereKey($team->getKey())->lockForUpdate()->firstOrFail();
+            abort_unless((string) $lockedTeam->getAttribute('user_id') === (string) auth()->id() && $lockedTeam->getAttribute('status') === 'active', 403);
+            $existing = $settings->resolve('team.setup', ['team' => $team->getKey()], [
+                'completed_steps' => [],
+                'team_name' => (string) $team->getAttribute('name'),
+                'timezone' => $this->timezone,
+                'integrations' => [],
+            ]);
+            abort_if((int) ($existing['revision'] ?? 0) !== $this->revision, 409, 'Setup was updated in another tab. Reload before saving.');
+            $completed = array_values(array_unique([...array_filter(array_map('intval', $existing['completed_steps'] ?? []), fn (int $completedStep): bool => $completedStep < $step), $step]));
+            $revision = $this->revision + 1;
+            $settings->put(new TeamSetupDefinition(), 'team', (string) $team->getKey(), array_replace($existing, $changes, ['completed_steps' => $completed, 'revision' => $revision]));
+            if ($step === 1) {
+                $lockedTeam->forceFill(['name' => $changes['team_name']])->save();
+            }
+            $this->completedSteps = $completed;
+            $this->revision = $revision;
+            unset($this->integrationStatus);
+        });
+    }
+
+    /** @param list<int> $required */
+    private function requireSteps(ScopedSettings $settings, Team $team, array $required): void
+    {
+        $stored = $settings->resolve('team.setup', ['team' => $team->getKey()], ['completed_steps' => []]);
+        if (array_diff($required, array_map('intval', $stored['completed_steps'] ?? [])) !== []) {
+            throw ValidationException::withMessages(['setup' => 'Complete the preceding setup steps before continuing.']);
+        }
     }
 }

--- a/app/Filament/App/Widgets/AccountSetupWidget.php
+++ b/app/Filament/App/Widgets/AccountSetupWidget.php
@@ -17,16 +17,21 @@ final class AccountSetupWidget extends Widget
 
     public bool $needsSetup = false;
 
+    public static function canView(): bool
+    {
+        return AccountSetup::canAccess();
+    }
+
     public function mount(CurrentTeamResolver $resolver, ScopedSettings $settings): void
     {
         $user = auth()->user();
         $team = $user === null ? null : $resolver->resolve($user, $user->current_team_id);
-        if ($team === null) {
+        if ($team === null || (string) $team->getAttribute('user_id') !== (string) $user->getAuthIdentifier()) {
             return;
         }
 
         $stored = $settings->resolve('team.setup', ['team' => $team->getKey()], ['completed_steps' => []]);
-        $this->needsSetup = ! in_array(3, array_map('intval', $stored['completed_steps'] ?? []), true);
+        $this->needsSetup = array_diff([1, 2, 3], array_map('intval', $stored['completed_steps'] ?? [])) !== [];
     }
 
     public function setupUrl(): string

--- a/docs/HOSTING_PRODUCT_ROADMAP.md
+++ b/docs/HOSTING_PRODUCT_ROADMAP.md
@@ -27,6 +27,10 @@ These are configuration indicators, not uptime probes. The overview does not ass
 
 ## Prioritized delivery backlog
 
+Onboarding hardening now binds the wizard to its originating team, rechecks owner access, derives step eligibility from persisted progress, and uses a locked revision plus a database transaction to reject stale-tab updates. Optional OAuth pairs are validated and secrets are not loaded back into inputs. The setup UI uses Filament-native controls and labels stored credentials as unverified storage. Runtime consumers for those team credentials and real connection verification remain outstanding.
+
+Source inspection also confirms that `CreateDomain`, `CreateVirtualHost`, and `ActivateDomain` currently write records; those actions alone do not configure a remote web server. A launch wizard must integrate a real execution/reconciliation adapter and verify the result rather than call these three actions and declare the site deployed.
+
 | Priority | Workflow | Existing surface to build on | Acceptance gate |
 | --- | --- | --- | --- |
 | P0 | Secure onboarding and connection readiness | Account setup, scoped settings, connected accounts, node credentials | Team owners authorize changes; stored credentials are distinguished from tested connections; reconnect, expiry and revoked-access paths are tested; no secret appears in client state or logs. |

--- a/resources/views/filament/app/pages/account-setup.blade.php
+++ b/resources/views/filament/app/pages/account-setup.blade.php
@@ -1,53 +1,110 @@
 <x-filament-panels::page>
-    <div class="mx-auto w-full max-w-5xl space-y-8">
-        <header class="rounded-2xl bg-gradient-to-br from-primary-700 to-primary-500 p-6 text-white shadow-sm md:p-8">
-            <div class="flex flex-col justify-between gap-6 md:flex-row md:items-end">
-                <div class="max-w-2xl">
-                    <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary-100">Getting started</p>
-                    <h1 class="mt-2 text-3xl font-semibold tracking-tight">Let’s get your account ready</h1>
-                    <p class="mt-3 text-sm leading-6 text-primary-50">Complete the essentials once, connect the services your project needs, then invite your team.</p>
-                </div>
-                <div class="rounded-xl bg-white/15 px-4 py-3 text-sm backdrop-blur"><span class="font-semibold">{{ count($completedSteps) }} of 3</span> steps complete</div>
-            </div>
-        </header>
-
-        <nav aria-label="Setup progress" class="grid gap-3 md:grid-cols-3">
-            @foreach ([1 => ['Workspace profile', 'Name and timezone', 'heroicon-o-building-office-2'], 2 => ['Integrations', 'OAuth and API keys', 'heroicon-o-key'], 3 => ['Ready to go', 'Review and finish', 'heroicon-o-check-circle']] as $number => [$label, $description, $icon])
-                <button type="button" wire:click="goToStep({{ $number }})" @disabled($number > 1 && ! in_array($number - 1, $completedSteps, true)) class="group rounded-2xl border p-4 text-left transition hover:-translate-y-0.5 hover:border-primary-500 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50 {{ $step === $number ? 'border-primary-500 bg-primary-50 ring-1 ring-primary-500 dark:bg-primary-950/30' : 'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900' }}">
-                    <span class="flex items-center gap-3"><span class="grid size-10 shrink-0 place-items-center rounded-xl {{ $step === $number ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-500 dark:bg-gray-800' }}"><x-filament::icon :icon="$icon" class="size-5" /></span><span><span class="block text-xs font-semibold uppercase tracking-wide text-gray-500">Step {{ $number }}</span><span class="mt-1 block font-semibold text-gray-950 dark:text-white">{{ $label }}</span></span></span>
-                    <span class="mt-3 block text-sm text-gray-600 dark:text-gray-400">{{ $description }}</span>
-                    @if (in_array($number, $completedSteps, true))<span class="mt-3 block text-xs font-semibold text-success-600 dark:text-success-400">Complete</span>@endif
-                </button>
+    <x-filament::section heading="Workspace setup" icon="heroicon-o-sparkles">
+        <x-slot name="description">Save your team profile, review optional credentials, and plan your first website. Only the team owner can change these settings.</x-slot>
+        <p>{{ count($completedSteps) }} of 3 setup steps complete</p>
+        <nav aria-label="Setup progress">
+            @foreach ([1 => 'Workspace profile', 2 => 'Optional credentials', 3 => 'Review and next steps'] as $number => $label)
+                <x-filament::button wire:key="setup-step-{{ $number }}" type="button" wire:click="goToStep({{ $number }})"
+                    :color="$step === $number ? 'primary' : 'gray'"
+                    :disabled="$number > 1 && count(array_diff(range(1, $number - 1), $completedSteps)) > 0"
+                    :aria-current="$step === $number ? 'step' : null">
+                    {{ $number }}. {{ $label }}{{ in_array($number, $completedSteps, true) ? ' — complete' : '' }}
+                </x-filament::button>
             @endforeach
         </nav>
+    </x-filament::section>
 
-        <section class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900 md:p-8">
-            @if ($step === 1)
-                <form wire:submit="saveProfile" class="space-y-7">
-                    <div><h2 class="text-xl font-semibold text-gray-950 dark:text-white">Tell us about your team</h2><p class="mt-2 text-sm text-gray-600 dark:text-gray-400">This information personalises the workspace for everyone on your team.</p></div>
-                    <div class="grid gap-5 md:grid-cols-2">
-                        <label class="block text-sm font-medium text-gray-800 dark:text-gray-200">Team name<input wire:model="teamName" required maxlength="255" class="mt-2 block w-full rounded-xl border-gray-300 bg-white px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"></label>
-                        <label class="block text-sm font-medium text-gray-800 dark:text-gray-200">Workspace timezone<select wire:model="timezone" required class="mt-2 block w-full rounded-xl border-gray-300 bg-white px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800">@foreach ($this->timezoneOptions() as $value => $label)<option value="{{ $value }}">{{ $label }}</option>@endforeach</select></label>
-                    </div>
-                    @error('teamName')<p class="text-sm text-danger-600">{{ $message }}</p>@enderror
-                    @error('timezone')<p class="text-sm text-danger-600">{{ $message }}</p>@enderror
-                    <button type="submit" class="rounded-xl bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-500" wire:loading.attr="disabled">Save and continue <span aria-hidden="true">→</span></button>
-                </form>
-            @elseif ($step === 2)
-                <form wire:submit="saveIntegrations" class="space-y-7">
-                    <div><h2 class="text-xl font-semibold text-gray-950 dark:text-white">Connect the services your project needs</h2><p class="mt-2 text-sm text-gray-600 dark:text-gray-400">Configure OAuth providers for social sign-in and API credentials for billing or automation. Secrets are encrypted before storage and never shown again.</p></div>
-                    <div class="grid gap-4 md:grid-cols-2">
-                        <div class="rounded-xl border border-gray-200 p-4 dark:border-gray-700"><div class="mb-4 flex items-center justify-between gap-3"><span class="font-semibold">GitHub OAuth</span><span class="text-xs {{ ($this->integrationStatus()['GitHub OAuth'] ?? false) ? 'text-success-600' : 'text-gray-500' }}">{{ ($this->integrationStatus()['GitHub OAuth'] ?? false) ? 'Configured' : 'Optional' }}</span></div><div class="space-y-3"><input wire:model="githubClientId" placeholder="Client ID" aria-label="GitHub OAuth client ID" maxlength="255" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"><input wire:model="githubClientSecret" type="password" placeholder="Client secret" aria-label="GitHub OAuth client secret" maxlength="1000" autocomplete="new-password" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"></div></div>
-                        <div class="rounded-xl border border-gray-200 p-4 dark:border-gray-700"><div class="mb-4 flex items-center justify-between gap-3"><span class="font-semibold">Google OAuth</span><span class="text-xs {{ ($this->integrationStatus()['Google OAuth'] ?? false) ? 'text-success-600' : 'text-gray-500' }}">{{ ($this->integrationStatus()['Google OAuth'] ?? false) ? 'Configured' : 'Optional' }}</span></div><div class="space-y-3"><input wire:model="googleClientId" placeholder="Client ID" aria-label="Google OAuth client ID" maxlength="255" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"><input wire:model="googleClientSecret" type="password" placeholder="Client secret" aria-label="Google OAuth client secret" maxlength="1000" autocomplete="new-password" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"></div></div>
-                        <div class="rounded-xl border border-gray-200 p-4 dark:border-gray-700 md:col-span-2"><div class="mb-4 flex items-center justify-between gap-3"><span class="font-semibold">Stripe API</span><span class="text-xs {{ ($this->integrationStatus()['Stripe API'] ?? false) ? 'text-success-600' : 'text-gray-500' }}">{{ ($this->integrationStatus()['Stripe API'] ?? false) ? 'Configured' : 'Optional' }}</span></div><input wire:model="stripeSecret" type="password" placeholder="Secret key (sk_live_… or sk_test_…)" aria-label="Stripe secret key" maxlength="1000" autocomplete="new-password" class="block w-full rounded-xl border-gray-300 px-3 py-2.5 dark:border-gray-600 dark:bg-gray-800"></div>
-                    </div>
-                    <div class="rounded-xl bg-gray-50 p-4 text-sm text-gray-600 dark:bg-gray-800/70 dark:text-gray-300"><span class="font-semibold text-gray-900 dark:text-white">No credentials yet?</span> Leave fields blank to skip them. You can update integrations later, and create personal API tokens from <a href="{{ $this->securityUrl() }}" class="font-semibold text-primary-600 hover:underline dark:text-primary-400">Account security</a>.</div>
-                    <div class="flex gap-3"><button type="button" wire:click="goToStep(1)" class="rounded-xl border border-gray-300 px-5 py-2.5 text-sm font-semibold dark:border-gray-600">Back</button><button type="submit" class="rounded-xl bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-primary-500" wire:loading.attr="disabled">Save and continue <span aria-hidden="true">→</span></button></div>
-                </form>
-            @else
-                <div class="space-y-7"><div><h2 class="text-xl font-semibold text-gray-950 dark:text-white">Your workspace is ready</h2><p class="mt-2 text-sm text-gray-600 dark:text-gray-400">The essentials for <strong>{{ $teamName }}</strong> are saved. Use this quick checklist before you start managing infrastructure.</p></div><div class="grid gap-3 sm:grid-cols-3"><div class="rounded-xl bg-success-50 p-4 text-sm text-success-800 dark:bg-success-950/30 dark:text-success-200"><x-filament::icon icon="heroicon-o-check-circle" class="mb-2 size-5" /><p class="font-semibold">Workspace profile</p><p class="mt-1 text-xs">Name and timezone saved.</p></div><div class="rounded-xl bg-success-50 p-4 text-sm text-success-800 dark:bg-success-950/30 dark:text-success-200"><x-filament::icon icon="heroicon-o-check-circle" class="mb-2 size-5" /><p class="font-semibold">Integrations</p><p class="mt-1 text-xs">Credentials saved securely.</p></div><div class="rounded-xl bg-gray-50 p-4 text-sm text-gray-700 dark:bg-gray-800/70 dark:text-gray-300"><x-filament::icon icon="heroicon-o-key" class="mb-2 size-5" /><p class="font-semibold">API access</p><p class="mt-1 text-xs">Create a token when automation is ready.</p></div></div><div class="flex flex-wrap gap-3"><button type="button" wire:click="goToStep(2)" class="rounded-xl border border-gray-300 px-5 py-2.5 text-sm font-semibold dark:border-gray-600">Review integrations</button><a href="{{ $this->securityUrl() }}" class="rounded-xl border border-gray-300 px-5 py-2.5 text-sm font-semibold dark:border-gray-600">Manage API access</a><button type="button" wire:click="finish" class="rounded-xl bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-primary-500" wire:loading.attr="disabled">Go to dashboard <span aria-hidden="true">→</span></button></div></div>
+    @if ($errors->any())
+        <x-filament::section heading="Please check your setup" icon="heroicon-o-exclamation-triangle" icon-color="danger">
+            <ul role="alert">
+                @foreach ($errors->all() as $error)
+                    <li wire:key="setup-error-{{ $loop->index }}">{{ $error }}</li>
+                @endforeach
+            </ul>
+        </x-filament::section>
+    @endif
+
+    @if ($step === 1)
+        <form wire:submit="saveProfile">
+            <x-filament::section heading="Tell us about your team">
+                <x-filament::fieldset label="Team name" required>
+                    <x-filament::input.wrapper :valid="! $errors->has('teamName')">
+                        <x-filament::input id="setup-team-name" aria-label="Team name" wire:model="teamName" required maxlength="255" />
+                    </x-filament::input.wrapper>
+                </x-filament::fieldset>
+                <x-filament::fieldset label="Workspace timezone" required>
+                    <x-filament::input.wrapper :valid="! $errors->has('timezone')">
+                        <x-filament::input.select aria-label="Workspace timezone" wire:model="timezone" required>
+                            @foreach ($this->timezoneOptions() as $value => $label)
+                                <option wire:key="timezone-{{ $value }}" value="{{ $value }}">{{ $label }}</option>
+                            @endforeach
+                        </x-filament::input.select>
+                    </x-filament::input.wrapper>
+                </x-filament::fieldset>
+                <x-slot name="footer">
+                    <x-filament::button type="submit" wire:loading.attr="disabled">Save and continue</x-filament::button>
+                </x-slot>
+            </x-filament::section>
+        </form>
+    @elseif ($step === 2)
+        <x-filament::section heading="Understand connection readiness" icon="heroicon-o-information-circle">
+            <p>Team credentials below are encrypted storage only. Saving them does not enable platform sign-in, connect an account, activate billing, or provision hosting. Those connections require a working integration adapter.</p>
+            <p>You do not need OAuth client secrets or a Stripe key to complete workspace setup. Leave unused providers blank. To connect your own GitHub or Google account, use the connected-accounts section of your profile.</p>
+            @if (\Illuminate\Support\Facades\Route::has('profile.show'))
+                <x-filament::button tag="a" :href="route('profile.show')" color="gray">Manage connected accounts</x-filament::button>
             @endif
-            <p wire:loading role="status" class="mt-5 text-sm text-gray-500">Saving your setup…</p>
-        </section>
-    </div>
+        </x-filament::section>
+        <form wire:submit="saveIntegrations">
+            <x-filament::section heading="Optional team credential storage">
+                <x-slot name="description">Provide a complete OAuth ID/secret pair. Blank fields preserve stored values. Changing a client ID requires its new secret. Saved secrets are never loaded back into this form.</x-slot>
+                @foreach ([
+                    'GitHub OAuth' => ['githubClientId' => ['Client ID', 'text', 255], 'githubClientSecret' => ['Client secret', 'password', 1000]],
+                    'Google OAuth' => ['googleClientId' => ['Client ID', 'text', 255], 'googleClientSecret' => ['Client secret', 'password', 1000]],
+                    'Stripe API' => ['stripeSecret' => ['Secret key', 'password', 1000]],
+                ] as $provider => $fields)
+                    <x-filament::fieldset wire:key="provider-{{ $provider }}" :label="$provider">
+                        <x-filament::badge color="gray">{{ ($this->integrationStatus[$provider] ?? false) ? 'Stored — not verified or connected' : 'Not stored — optional' }}</x-filament::badge>
+                        @foreach ($fields as $field => [$label, $type, $maxLength])
+                            <div wire:key="credential-{{ $field }}">
+                                <label for="{{ $field }}">{{ $label }}</label>
+                                <x-filament::input.wrapper :valid="! $errors->has($field)">
+                                    <x-filament::input :id="$field" wire:model="{{ $field }}" :type="$type" :maxlength="$maxLength" autocomplete="off" />
+                                </x-filament::input.wrapper>
+                            </div>
+                        @endforeach
+                    </x-filament::fieldset>
+                @endforeach
+                <x-slot name="footer">
+                    <x-filament::button type="button" wire:click="goToStep(1)" color="gray">Back</x-filament::button>
+                    <x-filament::button type="submit" wire:loading.attr="disabled">Save optional credentials and continue</x-filament::button>
+                </x-slot>
+            </x-filament::section>
+        </form>
+    @else
+        <x-filament::section heading="Review your workspace" icon="heroicon-o-clipboard-document-check">
+            <p>Workspace: {{ $teamName }} · Timezone: {{ $timezone }}</p>
+            <p>Your profile is saved and optional credentials have been reviewed. This completes account setup, not infrastructure provisioning.</p>
+            @foreach ($this->integrationStatus as $provider => $stored)
+                <p wire:key="review-{{ $provider }}">{{ $provider }}: {{ $stored ? 'Stored — connection not verified' : 'Skipped — no credentials stored' }}</p>
+            @endforeach
+            <x-slot name="footer">
+                <x-filament::button type="button" wire:click="goToStep(2)" color="gray">Review credentials</x-filament::button>
+                <x-filament::button type="button" wire:click="finish" wire:loading.attr="disabled">Finish account setup</x-filament::button>
+            </x-slot>
+        </x-filament::section>
+        <x-filament::section heading="Before launching your first website">
+            <ol>
+                <li>Ask your hosting administrator to connect a server or cluster and assign your hosting account and quota.</li>
+                <li>Add your domain and configure its runtime and document root.</li>
+                <li>Point DNS at the hosting service, deploy your site, and issue its HTTPS certificate.</li>
+                <li>Configure a backup destination and schedule, then verify a test restore.</li>
+            </ol>
+            <p>Use narrowly scoped personal API tokens only when automation needs them.</p>
+            <x-filament::button tag="a" :href="$this->securityUrl()" color="gray">Manage API access</x-filament::button>
+            @if (\App\Filament\App\Pages\Websites::canAccess())
+                <x-filament::button tag="a" :href="\App\Filament\App\Pages\Websites::getUrl(panel: 'app')" color="gray">Review websites</x-filament::button>
+            @endif
+        </x-filament::section>
+    @endif
+    <p wire:loading role="status">Updating setup…</p>
 </x-filament-panels::page>

--- a/resources/views/filament/app/widgets/account-setup-widget.blade.php
+++ b/resources/views/filament/app/widgets/account-setup-widget.blade.php
@@ -1,11 +1,11 @@
-@if ($needsSetup)
-    <x-filament-widgets::widget>
+<x-filament-widgets::widget :hidden="! $needsSetup">
+    @if ($needsSetup)
         <div class="flex flex-col gap-4 rounded-2xl border border-primary-200 bg-primary-50 p-5 dark:border-primary-900 dark:bg-primary-950/30 md:flex-row md:items-center md:justify-between">
             <div>
                 <p class="text-sm font-semibold text-primary-700 dark:text-primary-300">Complete your workspace setup</p>
-                <p class="mt-1 text-sm text-primary-900/80 dark:text-primary-100/80">Add your team details and optional OAuth/API credentials so your workspace is ready to use.</p>
+                <p class="mt-1 text-sm text-primary-900/80 dark:text-primary-100/80">Save your team profile, review optional credential storage, and see the next steps for launching a website.</p>
             </div>
             <a href="{{ $this->setupUrl() }}" class="inline-flex shrink-0 items-center justify-center rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500">Open setup guide</a>
         </div>
-    </x-filament-widgets::widget>
-@endif
+    @endif
+</x-filament-widgets::widget>

--- a/tests/Feature/AccountSetupTest.php
+++ b/tests/Feature/AccountSetupTest.php
@@ -1,11 +1,14 @@
 <?php
 
 use App\Filament\App\Pages\AccountSetup;
+use App\Filament\App\Widgets\AccountSetupWidget;
 use App\Models\User;
+use App\Settings\TeamSetupDefinition;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\DB;
 use Liberu\Foundation\Organizations\Models\Team;
 use Liberu\Foundation\Settings\Services\ScopedSettings;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
 use Livewire\Livewire;
 
 beforeEach(function (): void {
@@ -37,6 +40,7 @@ it('encrypts saved integration credentials and clears secret inputs', function (
     Livewire::actingAs($user)
         ->test(AccountSetup::class)
         ->set('githubClientId', 'github-client')
+        ->call('saveProfile')
         ->set('githubClientSecret', 'github-secret')
         ->set('stripeSecret', 'stripe-secret')
         ->call('saveIntegrations')
@@ -49,4 +53,174 @@ it('encrypts saved integration credentials and clears secret inputs', function (
 
     expect($stored)->not->toContain('github-secret')->not->toContain('stripe-secret')
         ->and(app(ScopedSettings::class)->resolve('team.setup', ['team' => $team->getKey()])['integrations']['github_client_secret'])->toBe('github-secret');
+});
+
+function setupOwner(): array
+{
+    $user = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $user->getKey()]);
+    $user->forceFill(['current_team_id' => $team->getKey()])->save();
+
+    return [$user, $team];
+}
+
+it('resumes from persisted progress and clamps query-string step skipping', function (): void {
+    [$user] = setupOwner();
+    Livewire::actingAs($user)->withQueryParams(['step' => 3])->test(AccountSetup::class)->assertSet('step', 1)
+        ->call('saveProfile')->assertSet('step', 2);
+    Livewire::withQueryParams([])->test(AccountSetup::class)->assertSet('step', 2);
+});
+
+it('requires persisted preceding steps for all forward actions', function (string $action, array $parameters): void {
+    [$user] = setupOwner();
+    Livewire::actingAs($user)->test(AccountSetup::class)->call($action, ...$parameters)
+        ->assertHasErrors(['setup'])->assertSet('completedSteps', []);
+})->with([
+    ['saveIntegrations', []], ['finish', []], ['goToStep', [2]], ['goToStep', [3]],
+]);
+
+it('locks progress and team context against client updates', function (string $field, mixed $value): void {
+    [$user] = setupOwner();
+    $component = Livewire::actingAs($user)->test(AccountSetup::class);
+    $this->expectException(CannotUpdateLockedPropertyException::class);
+    $component->set($field, $value);
+})->with([
+    ['step', 3], ['completedSteps', [1, 2, 3]], ['teamId', 'another-team'], ['revision', 99],
+]);
+
+it('rejects non-owner members even when they have an active team membership', function (): void {
+    [$owner, $team] = setupOwner();
+    $member = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $team->users()->attach($member, ['role' => 'admin', 'status' => 'active']);
+    Livewire::actingAs($member)->test(AccountSetup::class)->assertForbidden();
+});
+
+it('rejects team switching between opening the wizard and saving', function (): void {
+    [$user, $original] = setupOwner();
+    $other = Team::factory()->create(['user_id' => $user->getKey(), 'name' => 'Other team']);
+    $component = Livewire::actingAs($user)->test(AccountSetup::class)->set('teamName', 'Stale draft');
+    $user->forceFill(['current_team_id' => $other->getKey()])->save();
+    $component->call('saveProfile')->assertStatus(409);
+    expect($other->refresh()->getAttribute('name'))->toBe('Other team')
+        ->and($original->refresh()->getAttribute('name'))->not->toBe('Stale draft');
+});
+
+it('rejects stale tabs without overwriting newer settings or team names', function (): void {
+    [$user, $team] = setupOwner();
+    $first = Livewire::actingAs($user)->test(AccountSetup::class);
+    $second = Livewire::test(AccountSetup::class);
+    $first->set('teamName', 'First saved')->call('saveProfile');
+    $second->set('teamName', 'Stale second')->call('saveProfile')->assertStatus(409);
+    expect($team->refresh()->getAttribute('name'))->toBe('First saved');
+});
+
+it('rechecks team ownership after the wizard is opened', function (): void {
+    [$user, $team] = setupOwner();
+    $component = Livewire::actingAs($user)->test(AccountSetup::class);
+    $team->forceFill(['user_id' => User::factory()->create()->getKey()])->save();
+    $component->call('finish')->assertForbidden();
+});
+
+it('rejects whitespace-only team names before any changes', function (): void {
+    [$user, $team] = setupOwner();
+    $name = $team->getAttribute('name');
+    Livewire::actingAs($user)->test(AccountSetup::class)->set('teamName', '   ')->call('saveProfile')->assertHasErrors(['teamName']);
+    expect($team->refresh()->getAttribute('name'))->toBe($name);
+});
+
+it('requires complete OAuth credential pairs', function (string $field, string $error): void {
+    [$user] = setupOwner();
+    Livewire::actingAs($user)->test(AccountSetup::class)->call('saveProfile')
+        ->set($field, 'credential')->call('saveIntegrations')->assertHasErrors([$error]);
+})->with([
+    ['githubClientId', 'githubClientSecret'], ['githubClientSecret', 'githubClientSecret'],
+    ['googleClientId', 'googleClientSecret'], ['googleClientSecret', 'googleClientSecret'],
+]);
+
+it('preserves blank secrets and requires a matching new secret when changing OAuth client IDs', function (): void {
+    [$user, $team] = setupOwner();
+    Livewire::actingAs($user)->test(AccountSetup::class)->call('saveProfile')
+        ->set('githubClientId', 'old-id')->set('githubClientSecret', 'old-secret')->call('saveIntegrations');
+    $component = Livewire::test(AccountSetup::class)->assertSet('githubClientSecret', '')
+        ->assertDontSee('old-secret')->call('goToStep', 2)->call('saveIntegrations')->assertHasNoErrors();
+    expect(app(ScopedSettings::class)->resolve('team.setup', ['team' => $team->getKey()])['integrations']['github_client_secret'])->toBe('old-secret');
+    $component->call('goToStep', 2)->set('githubClientId', 'new-id')->call('saveIntegrations')
+        ->assertHasErrors(['githubClientSecret'])
+        ->set('githubClientSecret', 'new-secret')->call('saveIntegrations')->assertHasNoErrors();
+    expect(app(ScopedSettings::class)->resolve('team.setup', ['team' => $team->getKey()])['integrations']['github_client_secret'])->toBe('new-secret');
+});
+
+it('allows optional integrations to be skipped without claiming they are connected', function (): void {
+    [$user, $team] = setupOwner();
+    Livewire::actingAs($user)->test(AccountSetup::class)->call('saveProfile')->call('saveIntegrations')
+        ->assertSee('Skipped — no credentials stored')->assertSee('not infrastructure provisioning')
+        ->call('finish')->assertRedirect();
+    expect(app(ScopedSettings::class)->resolve('team.setup', ['team' => $team->getKey()])['completed_steps'])->toBe([1, 2, 3]);
+});
+
+it('invalidates later completion when the workspace profile changes', function (): void {
+    [$user] = setupOwner();
+    Livewire::actingAs($user)->test(AccountSetup::class)->call('saveProfile')->call('saveIntegrations')->call('finish');
+    Livewire::test(AccountSetup::class)->call('goToStep', 1)->call('saveProfile')
+        ->assertSet('completedSteps', [1])->call('finish')->assertHasErrors(['setup']);
+});
+
+it('reviews the saved profile rather than unsaved edits', function (): void {
+    [$user, $team] = setupOwner();
+    Livewire::actingAs($user)->test(AccountSetup::class)->call('saveProfile')->call('saveIntegrations')
+        ->call('goToStep', 1)->set('teamName', 'Unsaved name')->set('timezone', 'Europe/London')
+        ->call('goToStep', 3)->assertSet('teamName', $team->getAttribute('name'))->assertSet('timezone', 'UTC');
+});
+
+it('does not trust malformed legacy progress that skips the profile', function (): void {
+    [$user, $team] = setupOwner();
+    app(ScopedSettings::class)->put(new TeamSetupDefinition(), 'team', (string) $team->getKey(), ['completed_steps' => [2], 'integrations' => []]);
+    Livewire::actingAs($user)->test(AccountSetup::class)->assertSet('step', 1)
+        ->call('goToStep', 3)->assertHasErrors(['setup']);
+    Livewire::test(AccountSetupWidget::class)->assertSet('needsSetup', true);
+});
+
+it('keeps the setup reminder visible unless all steps are complete', function (array $completed, bool $expected): void {
+    [$user, $team] = setupOwner();
+    app(ScopedSettings::class)->put(new TeamSetupDefinition(), 'team', (string) $team->getKey(), ['completed_steps' => $completed, 'integrations' => []]);
+    Livewire::actingAs($user)->test(AccountSetupWidget::class)->assertSet('needsSetup', $expected);
+})->with([
+    [[], true], [[3], true], [[1, 3], true], [[1, 2, 3], false],
+]);
+
+it('does not offer owner-only setup to other team members', function (): void {
+    [$owner, $team] = setupOwner();
+    $member = User::factory()->create(['current_team_id' => $team->getKey()]);
+    $team->users()->attach($member, ['role' => 'admin', 'status' => 'active']);
+    $this->actingAs($member);
+    expect(AccountSetupWidget::canView())->toBeFalse();
+    Livewire::test(AccountSetupWidget::class)->assertSet('needsSetup', false);
+});
+
+it('rolls back scoped settings if updating the team profile fails', function (): void {
+    [$user, $team] = setupOwner();
+    $name = $team->getAttribute('name');
+    Team::updating(function (): void {
+        throw new RuntimeException('Profile update failed');
+    });
+    try {
+        Livewire::actingAs($user)->test(AccountSetup::class)->set('teamName', 'Should roll back')->call('saveProfile');
+        $this->fail('Expected the team update to fail.');
+    } catch (RuntimeException $exception) {
+        expect($exception->getMessage())->toBe('Profile update failed');
+    }
+    expect($team->refresh()->getAttribute('name'))->toBe($name)
+        ->and(app(ScopedSettings::class)->resolve('team.setup', ['team' => $team->getKey()]))->toBeNull();
+});
+
+it('resolves credential badges once per render rather than once per provider', function (): void {
+    [$user] = setupOwner();
+    Livewire::actingAs($user)->test(AccountSetup::class)->call('saveProfile');
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+    Livewire::test(AccountSetup::class)->assertSet('step', 2);
+    $reads = collect(DB::getQueryLog())->filter(fn (array $query): bool => str_starts_with($query['query'], 'select') && in_array('team.setup', $query['bindings'], true));
+    DB::disableQueryLog();
+
+    expect($reads)->toHaveCount(2);
 });


### PR DESCRIPTION
Binds setup to the original team and rechecks owner access on every request. Locks client progress, derives prerequisites from persisted state, rejects stale-tab updates with a revision check, and saves the profile/settings atomically. Validates complete OAuth pairs and requires new secrets when IDs change. Uses native Filament controls, visible validation errors, accurate optional credential-storage wording, and a website-launch checklist. Fixes missing Livewire root markup in the completed setup reminder. Adds regression coverage for access revocation, team switching, tampering, skipping, rollback, stale tabs, credential replacement, and cached status queries. Focused tests and Pint/PHPStan/build pass; full local regression is being rerun and CI must pass before merge. This does not claim runtime integration verification or complete hosting parity.