### PR TITLE
Execute encrypted file backups and verified restores

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,8 @@ FACEBOOK_CLIENT_ID=
 FACEBOOK_CLIENT_SECRET=
 TWITTER_CLIENT_ID=
 TWITTER_CLIENT_SECRET=
+
+# Optional operator-managed encrypted file backup executor (disabled until configured)
+HOSTING_BACKUP_ROOT=
+HOSTING_RESTORE_ROOT=
+HOSTING_BACKUP_KEY=

--- a/app/Console/Commands/BackupHostingFiles.php
+++ b/app/Console/Commands/BackupHostingFiles.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Hosting\Backups\LocalFileBackups;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Liberu\ControlPanel\Backups\BackupsServiceProvider;
+use Throwable;
+
+#[Signature('hosting:backup-files {source : Operator-configured source alias}')]
+#[Description('Create and verify an encrypted file backup from an allowlisted source')]
+class BackupHostingFiles extends Command
+{
+    public function handle(LocalFileBackups $backups): int
+    {
+        if (! app()->providerIsLoaded(BackupsServiceProvider::class)) {
+            $this->error('Enable the control-panel-backups module before executing backups.');
+
+            return self::FAILURE;
+        }
+        try {
+            $snapshot = $backups->backup((string) $this->argument('source'));
+            $this->info('Verified file snapshot: '.$snapshot->getKey());
+
+            return self::SUCCESS;
+        } catch (Throwable $exception) {
+            report($exception);
+            $this->error('Backup command failed. Review the operator log and snapshot status.');
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/RestoreHostingFiles.php
+++ b/app/Console/Commands/RestoreHostingFiles.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Hosting\Backups\LocalFileBackups;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Liberu\ControlPanel\Backups\BackupsServiceProvider;
+use Throwable;
+
+#[Signature('hosting:restore-files {snapshot : Verified snapshot UUID} {--team= : Owning team ID}')]
+#[Description('Verify and restore file backup bytes into a new private directory')]
+class RestoreHostingFiles extends Command
+{
+    public function handle(LocalFileBackups $backups): int
+    {
+        if (! app()->providerIsLoaded(BackupsServiceProvider::class) || blank($this->option('team'))) {
+            $this->error('Enable the backup module and supply the owning --team ID.');
+
+            return self::FAILURE;
+        }
+        try {
+            $restore = $backups->restore((string) $this->argument('snapshot'), (string) $this->option('team'));
+            $this->info('File restore completed: '.$restore->getKey());
+            $this->line('Private restore directory: '.$restore->getAttribute('target'));
+
+            return self::SUCCESS;
+        } catch (Throwable $exception) {
+            report($exception);
+            $this->error('Restore failed. Review the operator log; existing websites were not overwritten.');
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/app/Hosting/Backups/EncryptedFileArchive.php
+++ b/app/Hosting/Backups/EncryptedFileArchive.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Hosting\Backups;
+
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Filesystem\Filesystem;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use ZipArchive;
+
+final readonly class EncryptedFileArchive
+{
+    public function __construct(private Repository $config, private Filesystem $files) {}
+
+    /** @return array{checksum: string, size: int, files: int} */
+    public function create(string $source, string $workspace, #[\SensitiveParameter] string $key): array
+    {
+        $zip = $this->open($workspace.'/archive.zip', ZipArchive::CREATE | ZipArchive::EXCL);
+        $manifest = [];
+        $total = 0;
+        try {
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($source, \FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::SELF_FIRST);
+            foreach ($iterator as $entry) {
+                $relative = substr($entry->getPathname(), strlen($source) + 1);
+                $this->validatePath($relative);
+                $this->check(! $entry->isLink() && ($entry->isDir() || $entry->isFile()), 'Only regular files and directories can be backed up.');
+                $this->check(count($manifest) < $this->config->get('hosting-backups.max_files'), 'The backup contains too many entries.');
+                if ($entry->isDir()) {
+                    $manifest[$relative] = ['type' => 'directory'];
+                    $this->check($zip->addEmptyDir('files/'.$relative), 'Unable to archive a directory.');
+
+                    continue;
+                }
+
+                $input = fopen($entry->getPathname(), 'rb');
+                $this->check(is_resource($input), 'Unable to read a source file.');
+                $copy = $workspace.'/entry-'.count($manifest);
+                $output = fopen($copy, 'xb');
+                $this->check(is_resource($output), 'Unable to stage a source file.');
+                try {
+                    $stat = fstat($input);
+                    $current = lstat($entry->getPathname());
+                    $this->check($stat !== false && $current !== false && ($stat['mode'] & 0170000) === 0100000
+                        && $stat['ino'] === $current['ino'] && $stat['dev'] === $current['dev'] && $stat['nlink'] === 1
+                        && realpath($entry->getPathname()) === $source.'/'.$relative, 'A source file changed or is an unsafe link.');
+                    $size = stream_copy_to_stream($input, $output, $this->remainingBytes($total) + 1);
+                    $this->check($size !== false && $size <= $this->remainingBytes($total), 'The backup exceeds its byte limit.');
+                    $total += $size;
+                } finally {
+                    fclose($input);
+                    fclose($output);
+                }
+                $manifest[$relative] = ['type' => 'file', 'size' => $size, 'sha256' => hash_file('sha256', $copy)];
+                $this->check($zip->addFile($copy, 'files/'.$relative), 'Unable to archive a file.');
+                $this->encrypt($zip, 'files/'.$relative, $key);
+            }
+            $json = json_encode(['version' => 1, 'entries' => $manifest], JSON_THROW_ON_ERROR);
+            $this->check(strlen($json) <= $this->config->get('hosting-backups.max_manifest_bytes'), 'The backup manifest is too large.');
+            $this->check($zip->addFromString('manifest.json', $json), 'Unable to write the backup manifest.');
+            $this->encrypt($zip, 'manifest.json', $key);
+        } finally {
+            $this->check($zip->close(), 'Unable to finish the backup archive.');
+        }
+
+        $archive = $workspace.'/archive.zip';
+        $this->verify($archive, $key);
+
+        return ['checksum' => hash_file('sha256', $archive), 'size' => filesize($archive), 'files' => count($manifest)];
+    }
+
+    public function signature(string $archive, #[\SensitiveParameter] string $key, string $context): string
+    {
+        return hash_hmac_file('sha256', $archive, hash_hkdf('sha256', $key, 32, 'hosting-backups:authentication:v1:'.$context));
+    }
+
+    public function verify(string $archive, #[\SensitiveParameter] string $key, ?string $target = null): void
+    {
+        $zip = $this->open($archive, ZipArchive::RDONLY);
+        $zip->setPassword($this->password($key));
+        try {
+            $stat = $zip->statName('manifest.json');
+            $this->check($stat !== false && $stat['size'] <= $this->config->get('hosting-backups.max_manifest_bytes'), 'Missing or oversized backup manifest.');
+            $this->check(($stat['encryption_method'] ?? null) === ZipArchive::EM_AES_256, 'The backup manifest must use AES-256 encryption.');
+            $json = $zip->getFromName('manifest.json', (int) $this->config->get('hosting-backups.max_manifest_bytes') + 1);
+            $this->check(is_string($json) && strlen($json) <= $this->config->get('hosting-backups.max_manifest_bytes'), 'The backup manifest cannot be decrypted or exceeds its limit.');
+            $manifest = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+            $this->check(($manifest['version'] ?? null) === 1 && is_array($manifest['entries'] ?? null), 'Unsupported backup format.');
+            $entries = $manifest['entries'];
+            $this->check(count($entries) <= $this->config->get('hosting-backups.max_files') && $zip->numFiles === count($entries) + 1, 'The archive entries do not match the manifest.');
+            $total = 0;
+            foreach ($entries as $path => $entry) {
+                $this->validatePath((string) $path);
+                $this->check(is_array($entry) && in_array($entry['type'] ?? null, ['file', 'directory'], true), 'Invalid backup entry.');
+                if ($entry['type'] === 'directory') {
+                    $this->check($zip->locateName('files/'.$path.'/') !== false, 'Missing archived directory.');
+                    if ($target !== null) {
+                        $this->files->ensureDirectoryExists($target.'/'.$path, 0700);
+                    }
+
+                    continue;
+                }
+                $stat = $zip->statName('files/'.$path);
+                $this->check($stat !== false && is_int($entry['size'] ?? null) && $entry['size'] >= 0
+                    && $stat['size'] === $entry['size'] && $entry['size'] <= $this->remainingBytes($total)
+                    && is_string($entry['sha256'] ?? null), 'Invalid archived file size or checksum.');
+                $this->check(($stat['encryption_method'] ?? null) === ZipArchive::EM_AES_256, 'Archived file contents must use AES-256 encryption.');
+                $stream = $zip->getStream('files/'.$path);
+                $this->check(is_resource($stream), 'Unable to decrypt an archived file.');
+                $output = null;
+                try {
+                    if ($target !== null) {
+                        $this->files->ensureDirectoryExists(dirname($target.'/'.$path), 0700);
+                        $output = fopen($target.'/'.$path, 'xb');
+                        $this->check(is_resource($output), 'Restore refuses to overwrite an existing file.');
+                        chmod($target.'/'.$path, 0600);
+                    }
+                    $hash = hash_init('sha256');
+                    $size = 0;
+                    while (! feof($stream)) {
+                        $chunk = fread($stream, 65536);
+                        $this->check($chunk !== false && ($chunk !== '' || feof($stream)), 'Unable to read an archived file.');
+                        $size += strlen($chunk);
+                        $this->check($size <= $entry['size'], 'An archived file exceeds its declared size.');
+                        hash_update($hash, $chunk);
+                        if ($output !== null) {
+                            $this->check(fwrite($output, $chunk) === strlen($chunk), 'Unable to write restored file data.');
+                        }
+                    }
+                    $this->check($size === $entry['size'] && hash_equals($entry['sha256'], hash_final($hash)), 'Restored data does not match the backup checksum.');
+                    $total += $size;
+                } finally {
+                    fclose($stream);
+                    if (is_resource($output)) {
+                        fclose($output);
+                    }
+                }
+                if ($target !== null) {
+                    $this->check(hash_equals($entry['sha256'], hash_file('sha256', $target.'/'.$path)), 'Restored file verification failed on disk.');
+                }
+            }
+        } finally {
+            $zip->close();
+        }
+    }
+
+    private function validatePath(string $path): void
+    {
+        $this->check($path !== '' && ! preg_match('/[\\\\:\x00-\x1f\x7f]/', $path) && mb_check_encoding($path, 'UTF-8')
+            && ! array_intersect(explode('/', $path), ['', '.', '..']), 'Unsafe archive path.');
+    }
+
+    private function remainingBytes(int $used): int
+    {
+        return max(0, (int) $this->config->get('hosting-backups.max_bytes') - $used);
+    }
+
+    private function encrypt(ZipArchive $zip, string $name, #[\SensitiveParameter] string $key): void
+    {
+        $this->check($zip->setEncryptionName($name, ZipArchive::EM_AES_256, $this->password($key)), 'AES-256 archive encryption is unavailable.');
+    }
+
+    private function password(#[\SensitiveParameter] string $key): string
+    {
+        return bin2hex(hash_hkdf('sha256', $key, 32, 'hosting-backups:encryption:v1'));
+    }
+
+    private function open(string $path, int $flags): ZipArchive
+    {
+        $zip = new ZipArchive();
+        $this->check($zip->open($path, $flags) === true, 'Unable to open the backup archive.');
+
+        return $zip;
+    }
+
+    private function check(bool $condition, string $message): void
+    {
+        if (! $condition) {
+            throw new RuntimeException($message);
+        }
+    }
+}

--- a/app/Hosting/Backups/LocalFileBackups.php
+++ b/app/Hosting/Backups/LocalFileBackups.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Hosting\Backups;
+
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use Liberu\ControlPanel\Backups\Enums\RestoreStatus;
+use Liberu\ControlPanel\Backups\Enums\SnapshotStatus;
+use Liberu\ControlPanel\Backups\Models\BackupPolicy;
+use Liberu\ControlPanel\Backups\Models\BackupRestore;
+use Liberu\ControlPanel\Backups\Models\BackupSnapshot;
+use RuntimeException;
+use Throwable;
+
+final readonly class LocalFileBackups
+{
+    public function __construct(private Repository $config, private Filesystem $files, private EncryptedFileArchive $archives) {}
+
+    public function backup(string $sourceAlias): BackupSnapshot
+    {
+        $sources = $this->config->get('hosting-backups.sources', []);
+        $source = $sources[$sourceAlias] ?? null;
+        $this->check(is_array($source) && filled($source['team_id'] ?? null) && filled($source['policy_id'] ?? null), 'Unknown or incomplete backup source alias.');
+        $policy = BackupPolicy::query()->whereKey($source['policy_id'])->where('team_id', $source['team_id'])->first();
+        $this->check($policy !== null && $policy->getAttribute('active') && $policy->getAttribute('encrypted') && $policy->getAttribute('storage_driver') === 'local-files-v1', 'An active, encrypted local-files-v1 policy for this team is required.');
+        $sourceRoot = $this->root($source['path'] ?? null);
+        $archiveRoot = $this->root($this->config->get('hosting-backups.archive_root'), true);
+        $restoreRoot = $this->root($this->config->get('hosting-backups.restore_root'), true);
+        foreach ([$archiveRoot, $restoreRoot] as $root) {
+            $this->check(! $this->overlaps($sourceRoot, $root), 'Source, archive and restore directories must not overlap.');
+        }
+        $this->check(! $this->overlaps($archiveRoot, $restoreRoot), 'Archive and restore directories must not overlap.');
+        $keyId = (string) $this->config->get('hosting-backups.active_key');
+        $key = $this->key($keyId);
+        $id = (string) Str::uuid();
+        $snapshot = new BackupSnapshot();
+        $snapshot->forceFill([
+            'id' => $id, 'team_id' => $source['team_id'], 'policy_id' => $policy->getKey(),
+            'location' => $id.'.zip', 'status' => SnapshotStatus::Running,
+            'metadata' => ['driver' => 'local-files-v1', 'key_id' => $keyId, 'source_alias' => $sourceAlias],
+        ])->save();
+        $workspace = $archiveRoot.'/.creating-'.$id;
+        try {
+            $this->check(mkdir($workspace, 0700), 'Cannot create the private backup workspace.');
+            $result = $this->archives->create($sourceRoot, $workspace, $key);
+            $this->check(chmod($workspace.'/archive.zip', 0600), 'Cannot secure the backup archive permissions.');
+            // link() publishes without replacing an existing archive with the same name.
+            $this->check(link($workspace.'/archive.zip', $archiveRoot.'/'.$id.'.zip'), 'Cannot publish the backup archive.');
+            $snapshot->forceFill([
+                'status' => SnapshotStatus::Verified, 'checksum' => $result['checksum'],
+                'size_bytes' => $result['size'], 'verified_at' => now(),
+                'metadata' => [...$snapshot->getAttribute('metadata'), 'signature' => $this->archives->signature($archiveRoot.'/'.$id.'.zip', $key, $this->context($snapshot)), 'entries' => $result['files']],
+            ])->save();
+        } catch (Throwable $exception) {
+            $snapshot->forceFill(['status' => SnapshotStatus::Failed])->save();
+            throw $exception;
+        } finally {
+            if (is_dir($workspace)) {
+                $this->files->deleteDirectory($workspace);
+            }
+        }
+
+        return $snapshot->refresh();
+    }
+
+    public function restore(string $snapshotId, string $teamId): BackupRestore
+    {
+        $this->check(Str::isUuid($snapshotId), 'A valid snapshot ID is required.');
+        $snapshot = BackupSnapshot::query()->whereKey($snapshotId)->where('team_id', $teamId)->first();
+        $metadata = $snapshot?->getAttribute('metadata') ?? [];
+        $this->check($snapshot !== null && $snapshot->getAttribute('status') === SnapshotStatus::Verified
+            && ($metadata['driver'] ?? null) === 'local-files-v1'
+            && $snapshot->getAttribute('location') === $snapshotId.'.zip', 'A verified local-files-v1 snapshot in the requested team is required.');
+        $archiveRoot = $this->root($this->config->get('hosting-backups.archive_root'), true);
+        $restoreRoot = $this->root($this->config->get('hosting-backups.restore_root'), true);
+        $this->check(! $this->overlaps($archiveRoot, $restoreRoot), 'Archive and restore directories must not overlap.');
+        $archive = $archiveRoot.'/'.$snapshotId.'.zip';
+        $this->check(is_file($archive) && ! is_link($archive), 'The snapshot archive is missing or is a link.');
+        $key = $this->key((string) ($metadata['key_id'] ?? ''));
+        $id = (string) Str::uuid();
+        $target = $restoreRoot.'/'.$id;
+        $restore = new BackupRestore();
+        $restore->forceFill([
+            'id' => $id, 'team_id' => $teamId, 'snapshot_id' => $snapshotId, 'target' => $target,
+            'status' => RestoreStatus::Running, 'started_at' => now(), 'options' => ['driver' => 'local-files-v1', 'overwrite' => false],
+        ])->save();
+        $created = false;
+        try {
+            $checksum = $snapshot->getAttribute('checksum');
+            $this->check(is_string($checksum) && hash_equals($checksum, hash_file('sha256', $archive))
+                && is_string($metadata['signature'] ?? null)
+                && hash_equals($metadata['signature'], $this->archives->signature($archive, $key, $this->context($snapshot))), 'Backup integrity or authentication failed.');
+            $this->archives->verify($archive, $key);
+            $this->check(mkdir($target, 0700), 'Restore requires a new, private directory.');
+            $created = true;
+            $this->archives->verify($archive, $key, $target);
+            $restore->forceFill(['status' => RestoreStatus::Completed, 'finished_at' => now()])->save();
+        } catch (Throwable $exception) {
+            if ($created) {
+                $this->files->deleteDirectory($target);
+            }
+            $restore->forceFill(['status' => RestoreStatus::Failed, 'finished_at' => now(), 'error' => 'File restore failed; no existing website was overwritten.'])->save();
+            throw $exception;
+        }
+
+        return $restore->refresh();
+    }
+
+    private function root(mixed $path, bool $private = false): string
+    {
+        $this->check(is_string($path) && str_starts_with($path, '/') && ! is_link($path), 'Configure an existing absolute directory, not a symbolic link.');
+        $root = realpath($path);
+        $this->check($root !== false && $root !== '/' && is_dir($root), 'The configured directory is missing or unsafe.');
+        if ($private) {
+            $this->check((fileperms($root) & 0077) === 0, 'Archive and restore roots must be private (mode 0700).');
+        }
+
+        return $root;
+    }
+
+    private function overlaps(string $first, string $second): bool
+    {
+        return $first === $second || str_starts_with($first, $second.'/') || str_starts_with($second, $first.'/');
+    }
+
+    private function context(BackupSnapshot $snapshot): string
+    {
+        return json_encode(['team' => (string) $snapshot->getAttribute('team_id'), 'snapshot' => (string) $snapshot->getKey()], JSON_THROW_ON_ERROR);
+    }
+
+    private function key(string $id): string
+    {
+        $keys = $this->config->get('hosting-backups.keys', []);
+        $key = $keys[$id] ?? null;
+        $this->check(is_string($key) && strlen($key) >= 32, 'Configure a backup key of at least 32 random characters for this key ID.');
+
+        return $key;
+    }
+
+    private function check(bool $condition, string $message): void
+    {
+        if (! $condition) {
+            throw new RuntimeException($message);
+        }
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\App\Pages\FileRecovery;
 use App\Filament\App\Pages\Websites;
 use App\Filament\ModulePlugins;
 use App\Support\ThemeColors;
@@ -41,6 +42,7 @@ class AdminPanelProvider extends PanelProvider
             ->pages([
                 Dashboard::class,
                 Websites::class,
+                FileRecovery::class,
             ])
             ->navigationGroups([
                 NavigationGroup::make('Workspace'),

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,9 +1,11 @@
 <?php
 
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
+use Liberu\ControlPanel\Backups\BackupsServiceProvider;
 use Liberu\Foundation\ApplicationCore\Http\Middleware\SecurityHeaders;
 use Liberu\Foundation\Localization\Http\Middleware\SetLocale;
 
@@ -15,6 +17,12 @@ return Application::configure(basePath: dirname(__DIR__))
         channels: __DIR__.'/../routes/channels.php',
         health: '/up',
     )
+    ->withSchedule(function (Schedule $schedule): void {
+        if (app()->providerIsLoaded(BackupsServiceProvider::class)) {
+            $schedule->command('hosting:run-backup-schedules')->everyMinute()->onOneServer()->withoutOverlapping();
+            $schedule->command('hosting:prune-files')->dailyAt('02:00')->onOneServer()->withoutOverlapping();
+        }
+    })
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->appendToGroup('web', [SetLocale::class, SecurityHeaders::class]);
     })

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,11 +1,15 @@
 <?php
 
+use App\Hosting\Migrations\HostingMigrationBindingsServiceProvider;
 use App\Providers\Filament\AdminPanelProvider;
 use App\Providers\Filament\AppPanelProvider;
+use App\Providers\HostingMigrationServiceProvider;
 use Liberu\Foundation\ModuleManager\ModuleManagerServiceProvider;
 
 return [
     ModuleManagerServiceProvider::class,
+    HostingMigrationServiceProvider::class,
+    HostingMigrationBindingsServiceProvider::class,
     AdminPanelProvider::class,
     AppPanelProvider::class,
 ];

--- a/config/hosting-backups.php
+++ b/config/hosting-backups.php
@@ -16,4 +16,8 @@ return [
     'max_files' => 10000,
     'max_bytes' => 1024 * 1024 * 1024,
     'max_manifest_bytes' => 4 * 1024 * 1024,
+    // Panel requests stop at these record counts; operators retire copies explicitly.
+    // Enforce filesystem quotas too: these limits are not byte-level disk quotas.
+    'max_panel_snapshots' => 20,
+    'max_panel_restores' => 5,
 ];

--- a/config/hosting-backups.php
+++ b/config/hosting-backups.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    // Pre-create private directories outside all website source trees.
+    'archive_root' => env('HOSTING_BACKUP_ROOT'),
+    'restore_root' => env('HOSTING_RESTORE_ROOT'),
+
+    // Keep old keys when rotating: existing snapshots refer to their key ID.
+    'active_key' => 'v1',
+    'keys' => ['v1' => env('HOSTING_BACKUP_KEY')],
+
+    // Operator-controlled aliases, never paths supplied by panel users.
+    // 'example-site' => ['team_id' => '123', 'policy_id' => 'uuid', 'path' => '/srv/example'],
+    'sources' => [],
+
+    'max_files' => 10000,
+    'max_bytes' => 1024 * 1024 * 1024,
+    'max_manifest_bytes' => 4 * 1024 * 1024,
+];

--- a/config/queue.php
+++ b/config/queue.php
@@ -31,6 +31,17 @@ return [
 
     'connections' => [
 
+        // This connection intentionally shares the application database so requests
+        // and queued jobs commit atomically. Run a dedicated worker for this queue.
+        'hosting-backups' => [
+            'driver' => 'database',
+            'connection' => null,
+            'table' => 'jobs',
+            'queue' => 'hosting-backups',
+            'retry_after' => 960,
+            'after_commit' => false,
+        ],
+
         'sync' => [
             'driver' => 'sync',
         ],

--- a/docs/FILE_BACKUP_EXECUTOR.md
+++ b/docs/FILE_BACKUP_EXECUTOR.md
@@ -1,0 +1,52 @@
+# Encrypted local-file backup and restore
+
+The host now supplies a real file executor alongside the backup module's snapshot and restore records. It is opt-in and operator-only: it does not expose arbitrary filesystem paths to panel users, invoke shell commands, or automatically process every queued backup record.
+
+## What it does
+
+- Copies regular files from an operator-configured source alias into a private staging directory; includes hidden files and empty directories.
+- Rejects symbolic links, multiply linked files, special files, unsafe relative paths, overlapping source/storage roots, and configured entry/byte limits.
+- Creates an AES-256 ZIP with an encrypted manifest and file contents. ZIP directory listings and entry names are **not confidential**. Encryption uses PHP's [ZipArchive entry encryption](https://www.php.net/manual/en/ziparchive.setencryptionname.php).
+- Reads the archive back and verifies each file's size and SHA-256 before marking its snapshot verified. The archive HMAC is bound to its team and snapshot ID, with a key derived separately from the encryption password.
+- On restore, checks the archive checksum and HMAC, verifies all entries, writes into a newly generated private directory, then hashes the files read back from disk. No existing website or restore directory is replaced.
+- Records success/failure in the backup module's existing snapshot/restore tables. Ordinary failures clean up the newly created staging/restore directory. A process kill or cleanup failure can leave private partial directories for operator inspection; do not serve them as websites.
+
+This is a **file-only** backup. It does not create database dumps, snapshot a live application atomically, back up remote nodes, upload offsite, apply retention, restore ownership/ACLs, or activate the restored website. A verified archive is not proof of application consistency or recoverability of a live database. Quiesce the application or point the source at a stable filesystem snapshot before running it.
+
+## Configure deliberately
+
+1. Enable the `control-panel-backups` module through the deployment's existing module configuration.
+2. Install PHP's ZIP extension with AES-256 support. Run the executor as a dedicated, least-privileged service account, not root. Give it read access only to approved source trees. Other accounts must not be able to modify the archive/restore roots or their parents.
+3. Pre-create separate archive and restore roots with mode `0700`, outside every source tree and outside any web-served directory. Set `HOSTING_BACKUP_ROOT` and `HOSTING_RESTORE_ROOT` to their absolute paths.
+4. Generate at least 32 random characters for `HOSTING_BACKUP_KEY` using your secret manager. Keep an independent protected recovery copy. Never commit the value or put it in a command argument. Losing the key makes the archives unreadable.
+5. Create an active backup policy for the owning team with `storage_driver=local-files-v1` and `encrypted=true`.
+6. Add the source alias to `config/hosting-backups.php` through your deployment configuration. The policy and team IDs must agree. Paths are operator configuration, not team-editable settings:
+
+```php
+'sources' => [
+    'customer-site' => [
+        'team_id' => '123',
+        'policy_id' => 'existing-policy-uuid',
+        'path' => '/srv/customer-site-snapshot',
+    ],
+],
+```
+
+Configuration changes require the usual Laravel configuration-cache refresh. The default limits are 10,000 entries, 1 GiB of uncompressed file bytes, and a 4 MiB manifest. Reserve disk space for both plaintext staging copies and the encrypted archive. Private permissions do not replace disk encryption or secure handling of temporary data.
+
+## Execute and prove recovery
+
+```bash
+php artisan hosting:backup-files customer-site
+php artisan hosting:restore-files SNAPSHOT_UUID --team=123
+```
+
+The backup command returns a verified snapshot UUID. Restore returns a restore UUID and its generated private directory. Inspect the restored files and validate the application with a disposable database before any deliberate cutover. Restored files use mode `0600` and directories `0700`; ownership, executable modes and deployment permissions must be applied separately by the operator.
+
+The commands return nonzero on failure. Detailed errors go to the operator log; keys are not printed. Missing/invalid configuration is rejected rather than falling back to an unencrypted backup. Keep the application database, archive files, and all required key versions in your disaster-recovery plan.
+
+For key rotation, add a new entry under `keys`, change `active_key`, and retain old keys until every corresponding snapshot is retired. Existing snapshots select their recorded key ID. Rotation does not re-encrypt old archives.
+
+## Verification scope
+
+`tests/Feature/LocalFileBackupsTest.php` uses isolated real filesystem fixtures and ZIP encryption, not mocked file contents. It covers binary/Unicode/hidden files, empty trees, repeated non-overwriting restores, corrupted archives, wrong-team access, metadata team reassignment, key rotation, unsafe links and paths, resource limits, and the CLI path. These tests do not establish remote-host, database, offsite-storage or live-application recovery guarantees.

--- a/docs/FILE_BACKUP_EXECUTOR.md
+++ b/docs/FILE_BACKUP_EXECUTOR.md
@@ -1,6 +1,6 @@
 # Encrypted local-file backup and restore
 
-The host now supplies a real file executor alongside the backup module's snapshot and restore records. It is opt-in and operator-only: it does not expose arbitrary filesystem paths to panel users, invoke shell commands, or automatically process every queued backup record.
+The host supplies a real file executor alongside the backup module's snapshot and restore records. Configuration is opt-in and operator-controlled; team owners can request approved backups and private restores through the panels. It does not expose arbitrary filesystem paths to panel users, invoke shell commands, or automatically process every queued backup record.
 
 ## What it does
 
@@ -11,7 +11,7 @@ The host now supplies a real file executor alongside the backup module's snapsho
 - On restore, checks the archive checksum and HMAC, verifies all entries, writes into a newly generated private directory, then hashes the files read back from disk. No existing website or restore directory is replaced.
 - Records success/failure in the backup module's existing snapshot/restore tables. Ordinary failures clean up the newly created staging/restore directory. A process kill or cleanup failure can leave private partial directories for operator inspection; do not serve them as websites.
 
-This is a **file-only** backup. It does not create database dumps, snapshot a live application atomically, back up remote nodes, upload offsite, apply retention, restore ownership/ACLs, or activate the restored website. A verified archive is not proof of application consistency or recoverability of a live database. Quiesce the application or point the source at a stable filesystem snapshot before running it.
+This is a **file-only** backup. It does not create database dumps, snapshot a live application atomically, back up remote nodes, upload offsite, restore ownership/ACLs, or activate the restored website. The operator can apply policy-based retention to verified local-file snapshots with `hosting:prune-files`; it deletes only expired archives and their records, and skips snapshots with queued or running restores. A verified archive is not proof of application consistency or recoverability of a live database. Quiesce the application or point the source at a stable filesystem snapshot before running it.
 
 ## Configure deliberately
 
@@ -39,6 +39,7 @@ Configuration changes require the usual Laravel configuration-cache refresh. The
 ```bash
 php artisan hosting:backup-files customer-site
 php artisan hosting:restore-files SNAPSHOT_UUID --team=123
+php artisan hosting:prune-files --team=123
 ```
 
 The backup command returns a verified snapshot UUID. Restore returns a restore UUID and its generated private directory. Inspect the restored files and validate the application with a disposable database before any deliberate cutover. Restored files use mode `0600` and directories `0700`; ownership, executable modes and deployment permissions must be applied separately by the operator.
@@ -47,6 +48,26 @@ The commands return nonzero on failure. Detailed errors go to the operator log; 
 
 For key rotation, add a new entry under `keys`, change `active_key`, and retain old keys until every corresponding snapshot is retired. Existing snapshots select their recorded key ID. Rotation does not re-encrypt old archives.
 
+## Panel requests and background worker
+
+After deploying the migrations, team owners can use **Backups → File backup & recovery** in the app panel or their selected admin tenant. Members without ownership cannot execute these operations. The page lists only approved source aliases and the team's latest 50 verified file snapshots, not paths or encryption keys. Requests and their database queue jobs are committed atomically.
+
+Run a dedicated supervised worker under the least-privileged account described above:
+
+```bash
+php artisan queue:work hosting-backups --queue=hosting-backups --timeout=900 --tries=1
+```
+
+This uses the application's database and `jobs` table, independently of the default queue connection. A Redis/Horizon worker does not consume this queue. Keep its 960-second visibility timeout above the 900-second job timeout; allow graceful worker termination longer than the job timeout. Refresh configuration and restart workers after changing source aliases, keys or limits.
+
+The worker rechecks ownership, active team access, policy eligibility, source configuration and limits before execution. Only one pending/running request per team is allowed; pending work can be cancelled. The panel polls request status, and shows snapshot/restore IDs on completion. An administrator must inspect the private restored directory before any cutover. Retention is an operator action; run `hosting:prune-files` from a supervised maintenance schedule after confirming that no worker is still using the archives.
+
+Default panel limits are 20 retained snapshot records and five restore copies per team. They are admission limits, not filesystem quotas. Configure operating-system disk quotas and run the retention command according to each policy; never delete records merely to reset counters while leaving their files behind.
+
+An interrupted running job retains its team reservation as `review_required`; a hard kill can leave it `running`. Do not blindly retry, cancel or clear its reservation: stop and confirm the old worker is no longer executing, inspect the snapshot/restore records and private partial directories, and reconcile the filesystem outcome before an operator updates the request and releases `active_key`. Automatic interruption reconciliation is not implemented.
+
 ## Verification scope
 
 `tests/Feature/LocalFileBackupsTest.php` uses isolated real filesystem fixtures and ZIP encryption, not mocked file contents. It covers binary/Unicode/hidden files, empty trees, repeated non-overwriting restores, corrupted archives, wrong-team access, metadata team reassignment, key rotation, unsafe links and paths, resource limits, and the CLI path. These tests do not establish remote-host, database, offsite-storage or live-application recovery guarantees.
+
+`tests/Feature/FileBackupWorkflowTest.php` covers Filament actions through serialized database-queue execution and real restored bytes, tenant isolation, revoked access, changed configuration, limits, cancellation, duplicate deliveries and interrupted workers. Livewire component tests do not substitute for real-browser or staging-host acceptance testing.

--- a/docs/HOSTING_PRODUCT_ROADMAP.md
+++ b/docs/HOSTING_PRODUCT_ROADMAP.md
@@ -31,6 +31,8 @@ Onboarding hardening now binds the wizard to its originating team, rechecks owne
 
 Source inspection also confirms that `CreateDomain`, `CreateVirtualHost`, and `ActivateDomain` currently write records; those actions alone do not configure a remote web server. A launch wizard must integrate a real execution/reconciliation adapter and verify the result rather than call these three actions and declare the site deployed.
 
+The first real recovery executor is documented in [Encrypted local-file backups](FILE_BACKUP_EXECUTOR.md): operator-allowlisted sources, encrypted file archives, authenticated team/snapshot ownership, checksum verification, and non-overwriting restores tested against disposable filesystem fixtures. Database-consistent backups, remote/offsite storage, scheduling, retention and live application recovery remain required for the broader backup workflow.
+
 | Priority | Workflow | Existing surface to build on | Acceptance gate |
 | --- | --- | --- | --- |
 | P0 | Secure onboarding and connection readiness | Account setup, scoped settings, connected accounts, node credentials | Team owners authorize changes; stored credentials are distinguished from tested connections; reconnect, expiry and revoked-access paths are tested; no secret appears in client state or logs. |

--- a/modules/control-panel-backups/src/Actions/CreateSchedule.php
+++ b/modules/control-panel-backups/src/Actions/CreateSchedule.php
@@ -8,9 +8,12 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Liberu\ControlPanel\Backups\Models\BackupPolicy;
 use Liberu\ControlPanel\Backups\Models\BackupSchedule;
+use Liberu\ControlPanel\Backups\Services\BackupScheduleCalculator;
 
 final class CreateSchedule
 {
+    public function __construct(private readonly BackupScheduleCalculator $calculator) {}
+
     public function execute(BackupPolicy $policy, string $cron, string $timezone = 'UTC'): BackupSchedule
     {
         $cron = trim($cron);
@@ -18,6 +21,8 @@ final class CreateSchedule
             throw ValidationException::withMessages(['cron' => 'A five-field cron schedule is required.']);
         }
 
-        return BackupSchedule::query()->create(['id' => (string) Str::uuid(), 'team_id' => $policy->team_id, 'policy_id' => $policy->getKey(), 'cron' => $cron, 'timezone' => $timezone, 'active' => true]);
+        $nextRunAt = $this->calculator->next($cron, $timezone, now());
+
+        return BackupSchedule::query()->create(['id' => (string) Str::uuid(), 'team_id' => $policy->team_id, 'policy_id' => $policy->getKey(), 'cron' => $cron, 'timezone' => $timezone, 'active' => true, 'next_run_at' => $nextRunAt]);
     }
 }

--- a/modules/control-panel-backups/src/Actions/UpdateSchedule.php
+++ b/modules/control-panel-backups/src/Actions/UpdateSchedule.php
@@ -6,9 +6,12 @@ namespace Liberu\ControlPanel\Backups\Actions;
 
 use Illuminate\Validation\ValidationException;
 use Liberu\ControlPanel\Backups\Models\BackupSchedule;
+use Liberu\ControlPanel\Backups\Services\BackupScheduleCalculator;
 
 final class UpdateSchedule
 {
+    public function __construct(private readonly BackupScheduleCalculator $calculator) {}
+
     /** @param array<string, mixed> $attributes */
     public function execute(BackupSchedule $schedule, array $attributes): BackupSchedule
     {
@@ -23,7 +26,7 @@ final class UpdateSchedule
             throw ValidationException::withMessages(['timezone' => 'A valid timezone is required.']);
         }
 
-        $schedule->forceFill(['cron' => $cron, 'timezone' => $timezone, 'active' => $attributes['active'] ?? $schedule->active])->save();
+        $schedule->forceFill(['cron' => $cron, 'timezone' => $timezone, 'active' => $attributes['active'] ?? $schedule->active, 'next_run_at' => $this->calculator->next($cron, $timezone, now())])->save();
 
         return $schedule->refresh();
     }

--- a/modules/control-panel-backups/src/BackupsServiceProvider.php
+++ b/modules/control-panel-backups/src/BackupsServiceProvider.php
@@ -17,6 +17,7 @@ use Liberu\ControlPanel\Backups\Actions\RequestRestore;
 use Liberu\ControlPanel\Backups\Actions\UpdateDestination;
 use Liberu\ControlPanel\Backups\Actions\UpdatePolicy;
 use Liberu\ControlPanel\Backups\Actions\UpdateSchedule;
+use Liberu\ControlPanel\Backups\Services\BackupScheduleCalculator;
 
 final class BackupsServiceProvider extends ServiceProvider
 {
@@ -34,6 +35,7 @@ final class BackupsServiceProvider extends ServiceProvider
         $this->app->scoped(UpdatePolicy::class);
         $this->app->scoped(UpdateDestination::class);
         $this->app->scoped(UpdateSchedule::class);
+        $this->app->scoped(BackupScheduleCalculator::class);
     }
 
     public function boot(): void

--- a/modules/control-panel-backups/src/Models/BackupSnapshot.php
+++ b/modules/control-panel-backups/src/Models/BackupSnapshot.php
@@ -7,6 +7,7 @@ namespace Liberu\ControlPanel\Backups\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Liberu\ControlPanel\Backups\Enums\SnapshotStatus;
 
 final class BackupSnapshot extends Model
@@ -25,5 +26,10 @@ final class BackupSnapshot extends Model
     public function policy(): BelongsTo
     {
         return $this->belongsTo(BackupPolicy::class, 'policy_id');
+    }
+
+    public function restores(): HasMany
+    {
+        return $this->hasMany(BackupRestore::class, 'snapshot_id');
     }
 }

--- a/modules/control-panel-kubernetes-api/routes/api.php
+++ b/modules/control-panel-kubernetes-api/routes/api.php
@@ -12,6 +12,8 @@ Route::prefix('api/v1/control-panel/kubernetes')->middleware(['api', 'auth:sanct
     Route::get('/assets', [ClusterController::class, 'assets'])->name('control-panel.kubernetes.assets.index');
     Route::post('/resources', [ClusterController::class, 'resourceRecord'])->name('control-panel.kubernetes.resources.store');
     Route::post('/assets', [ClusterController::class, 'asset'])->name('control-panel.kubernetes.assets.store');
+    Route::post('/workloads/{workload}/reconcile', [ClusterController::class, 'reconcileWorkload'])->name('control-panel.kubernetes.workloads.reconcile');
+    Route::post('/helm-releases/{release}/rollback', [ClusterController::class, 'rollbackHelmRelease'])->name('control-panel.kubernetes.helm-releases.rollback');
     Route::post('/nodes/{node}/cordon', [NodeController::class, 'cordon'])->name('control-panel.kubernetes.nodes.cordon');
     Route::post('/nodes/{node}/uncordon', [NodeController::class, 'uncordon'])->name('control-panel.kubernetes.nodes.uncordon');
     Route::post('/nodes/{node}/drain', [NodeController::class, 'drain'])->name('control-panel.kubernetes.nodes.drain');

--- a/modules/control-panel-kubernetes-api/src/Http/Controllers/ClusterController.php
+++ b/modules/control-panel-kubernetes-api/src/Http/Controllers/ClusterController.php
@@ -8,9 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Liberu\ControlPanel\Kubernetes\Actions\ArchiveCluster;
+use Liberu\ControlPanel\Kubernetes\Actions\ReconcileWorkload;
 use Liberu\ControlPanel\Kubernetes\Actions\RecordKubernetesResource;
 use Liberu\ControlPanel\Kubernetes\Actions\RegisterCluster;
 use Liberu\ControlPanel\Kubernetes\Actions\RegisterKubernetesAsset;
+use Liberu\ControlPanel\Kubernetes\Actions\RollbackHelmRelease;
 use Liberu\ControlPanel\Kubernetes\Actions\SuspendCluster;
 use Liberu\ControlPanel\Kubernetes\Models\Cluster;
 use Liberu\ControlPanel\Kubernetes\Models\HelmRelease;
@@ -152,6 +154,25 @@ final class ClusterController
         $item = $register->execute(array_merge($data['payload'], ['kind' => $data['kind'], 'team_id' => $teamId]));
 
         return response()->json(['data' => ['id' => $item->getKey(), 'type' => 'control-panel-kubernetes-'.$data['kind'], 'attributes' => $item->only(self::ASSET_FIELDS[$data['kind']])]], 201);
+    }
+
+    public function reconcileWorkload(Request $request, KubernetesWorkload $workload, ReconcileWorkload $reconcile): JsonResponse
+    {
+        abort_if($request->user()?->current_team_id === null, 403, 'A current team is required.');
+        abort_unless((string) $workload->team_id === (string) $request->user()?->current_team_id, 404);
+        $item = $reconcile->execute($workload);
+
+        return response()->json(['data' => ['id' => $item->getKey(), 'type' => 'control-panel-kubernetes-workload', 'attributes' => $item->only(self::ASSET_FIELDS['workload'])]]);
+    }
+
+    public function rollbackHelmRelease(Request $request, HelmRelease $release, RollbackHelmRelease $rollback): JsonResponse
+    {
+        abort_if($request->user()?->current_team_id === null, 403, 'A current team is required.');
+        abort_unless((string) $release->team_id === (string) $request->user()?->current_team_id, 404);
+        $data = $request->validate(['revision' => ['required', 'integer', 'min:1']]);
+        $item = $rollback->execute($release, $data['revision']);
+
+        return response()->json(['data' => ['id' => $item->getKey(), 'type' => 'control-panel-kubernetes-helm', 'attributes' => $item->only(self::ASSET_FIELDS['helm'])]]);
     }
 
     private static function resource(Cluster $item): array

--- a/modules/control-panel-kubernetes/src/Actions/RegisterKubernetesAsset.php
+++ b/modules/control-panel-kubernetes/src/Actions/RegisterKubernetesAsset.php
@@ -48,6 +48,18 @@ final class RegisterKubernetesAsset
         } else {
             unset($a['kind']);
         }
+        if ($kind === 'autoscaling') {
+            $target = trim((string) ($a['target'] ?? ''));
+            $min = (int) ($a['min_replicas'] ?? 0);
+            $max = (int) ($a['max_replicas'] ?? 0);
+            if ($target === '' || $min < 1 || $max < $min) {
+                throw ValidationException::withMessages(['autoscaling' => 'An autoscaler needs a target and valid replica bounds.']);
+            }
+            $a['metric'] = strtolower(trim((string) ($a['metric'] ?? 'cpu')));
+            if (! in_array($a['metric'], ['cpu', 'memory', 'requests-per-second'], true)) {
+                throw ValidationException::withMessages(['metric' => 'Unsupported autoscaler metric.']);
+            }
+        }
 
         return $map[$kind]::query()->create($a);
     }

--- a/modules/control-panel-kubernetes/src/KubernetesServiceProvider.php
+++ b/modules/control-panel-kubernetes/src/KubernetesServiceProvider.php
@@ -6,16 +6,25 @@ namespace Liberu\ControlPanel\Kubernetes;
 
 use Illuminate\Support\ServiceProvider;
 use Liberu\ControlPanel\Kubernetes\Actions\DeleteHelmRelease;
+use Liberu\ControlPanel\Kubernetes\Actions\ReconcileWorkload;
+use Liberu\ControlPanel\Kubernetes\Actions\RecordHelmRevision;
 use Liberu\ControlPanel\Kubernetes\Actions\RecordKubernetesResource;
 use Liberu\ControlPanel\Kubernetes\Actions\RegisterCluster;
 use Liberu\ControlPanel\Kubernetes\Actions\RegisterKubernetesAsset;
+use Liberu\ControlPanel\Kubernetes\Actions\RollbackHelmRelease;
 use Liberu\ControlPanel\Kubernetes\Actions\UpdateHelmRelease;
+use Liberu\ControlPanel\Kubernetes\Contracts\WorkloadReconciler;
 use Liberu\ControlPanel\Kubernetes\Queries\ListClusters;
+use Liberu\ControlPanel\Kubernetes\Services\UnavailableWorkloadReconciler;
 
 final class KubernetesServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->app->scoped(WorkloadReconciler::class, UnavailableWorkloadReconciler::class);
+        $this->app->scoped(ReconcileWorkload::class);
+        $this->app->scoped(RecordHelmRevision::class);
+        $this->app->scoped(RollbackHelmRelease::class);
         $this->app->scoped(DeleteHelmRelease::class);
         $this->app->scoped(RegisterCluster::class);
         $this->app->scoped(ListClusters::class);

--- a/modules/control-panel-kubernetes/src/Models/HelmRelease.php
+++ b/modules/control-panel-kubernetes/src/Models/HelmRelease.php
@@ -6,6 +6,7 @@ namespace Liberu\ControlPanel\Kubernetes\Models;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 final class HelmRelease extends Model
 {
@@ -18,5 +19,10 @@ final class HelmRelease extends Model
     protected function casts(): array
     {
         return ['values' => 'array'];
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(HelmRevision::class, 'release_id');
     }
 }

--- a/modules/control-panel-kubernetes/src/Models/KubernetesWorkload.php
+++ b/modules/control-panel-kubernetes/src/Models/KubernetesWorkload.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\ControlPanel\Kubernetes\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 
 final class KubernetesWorkload extends Model
 {
+    use HasUuids;
+
     protected $table = 'control_panel_kubernetes_workloads';
 
     protected $fillable = ['id', 'team_id', 'cluster_id', 'namespace', 'name', 'kind', 'image', 'replicas', 'status', 'spec'];

--- a/modules/control-panel-web-hosting-api/routes/api.php
+++ b/modules/control-panel-web-hosting-api/routes/api.php
@@ -29,6 +29,9 @@ Route::prefix('api/v1/control-panel/web-hosting')
         Route::get('/cron-jobs/{job}/executions', [DomainController::class, 'cronExecutions'])->name('control-panel.web-hosting.cron-jobs.executions.index');
         Route::post('/cron-jobs/{job}/executions', [DomainController::class, 'recordCronExecution'])->name('control-panel.web-hosting.cron-jobs.executions.store');
         Route::post('/domains/{domain}/virtual-hosts', [DomainController::class, 'virtualHost'])->name('control-panel.web-hosting.virtual-hosts.store');
+        Route::post('/domains/{domain}/launches', [DomainController::class, 'launch'])->name('control-panel.web-hosting.launches.store');
+        Route::post('/launches/{launch}/run', [DomainController::class, 'runLaunch'])->name('control-panel.web-hosting.launches.run');
+        Route::get('/launches/{launch}', [DomainController::class, 'showLaunch'])->name('control-panel.web-hosting.launches.show');
         Route::patch('/virtual-hosts/{virtualHost}', [DomainController::class, 'updateVirtualHost'])->name('control-panel.web-hosting.virtual-hosts.update');
         Route::delete('/virtual-hosts/{virtualHost}', [DomainController::class, 'deleteVirtualHost'])->name('control-panel.web-hosting.virtual-hosts.delete');
         Route::post('/domains/{domain}/redirects', [DomainController::class, 'redirect'])->name('control-panel.web-hosting.redirects.store');
@@ -50,6 +53,11 @@ Route::prefix('api/v1/control-panel/web-hosting')
         Route::get('/applications/{application}/performance', [DomainController::class, 'applicationPerformance'])->name('control-panel.web-hosting.applications.performance');
         Route::post('/applications/{application}/health-checks', [DomainController::class, 'applicationHealth'])->name('control-panel.web-hosting.applications.health');
         Route::post('/applications/{application}/wordpress-update-checks', [DomainController::class, 'wordpressUpdate'])->name('control-panel.web-hosting.applications.wordpress-update-check');
+        Route::post('/applications/{application}/wordpress/clone', [DomainController::class, 'wordpressClone'])->name('control-panel.web-hosting.applications.wordpress.clone');
+        Route::post('/applications/{application}/wordpress/update', [DomainController::class, 'wordpressUpdateOperation'])->name('control-panel.web-hosting.applications.wordpress.update');
+        Route::post('/applications/{application}/wordpress/rollback', [DomainController::class, 'wordpressRollback'])->name('control-panel.web-hosting.applications.wordpress.rollback');
+        Route::post('/wordpress-operations/{operation}/run', [DomainController::class, 'runWordPressOperation'])->name('control-panel.web-hosting.wordpress-operations.run');
+        Route::get('/wordpress-operations/{operation}', [DomainController::class, 'showWordPressOperation'])->name('control-panel.web-hosting.wordpress-operations.show');
         Route::post('/domains/{domain}/hotlink-protection', [WebProtectionController::class, 'hotlink'])->name('control-panel.web-hosting.hotlink-protection.store');
         Route::post('/domains/{domain}/directory-protections', [WebProtectionController::class, 'directory'])->name('control-panel.web-hosting.directory-protections.store');
         Route::post('/directory-protections/{protection}/users', [WebProtectionController::class, 'directoryUser'])->name('control-panel.web-hosting.directory-protections.users.store');

--- a/modules/control-panel-web-hosting-api/src/Http/Controllers/DomainController.php
+++ b/modules/control-panel-web-hosting-api/src/Http/Controllers/DomainController.php
@@ -18,6 +18,8 @@ use Liberu\ControlPanel\WebHosting\Actions\CreateMimeType;
 use Liberu\ControlPanel\WebHosting\Actions\CreateRedirect;
 use Liberu\ControlPanel\WebHosting\Actions\CreateSubdomain;
 use Liberu\ControlPanel\WebHosting\Actions\CreateVirtualHost;
+use Liberu\ControlPanel\WebHosting\Actions\CreateWebsiteLaunch;
+use Liberu\ControlPanel\WebHosting\Actions\CreateWordPressOperation;
 use Liberu\ControlPanel\WebHosting\Actions\DeleteCronJob;
 use Liberu\ControlPanel\WebHosting\Actions\DeleteHostedApplication;
 use Liberu\ControlPanel\WebHosting\Actions\DeleteRedirect;
@@ -29,6 +31,8 @@ use Liberu\ControlPanel\WebHosting\Actions\RegisterGitDeployment;
 use Liberu\ControlPanel\WebHosting\Actions\RegisterHostingResource;
 use Liberu\ControlPanel\WebHosting\Actions\RequestCertificate;
 use Liberu\ControlPanel\WebHosting\Actions\RequestGitDeployment;
+use Liberu\ControlPanel\WebHosting\Actions\RunWebsiteLaunch;
+use Liberu\ControlPanel\WebHosting\Actions\RunWordPressOperation;
 use Liberu\ControlPanel\WebHosting\Actions\SavePhpConfiguration;
 use Liberu\ControlPanel\WebHosting\Actions\SuspendDomain;
 use Liberu\ControlPanel\WebHosting\Actions\UpdateCronJob;
@@ -37,6 +41,7 @@ use Liberu\ControlPanel\WebHosting\Actions\UpdateHostedApplication;
 use Liberu\ControlPanel\WebHosting\Actions\UpdateRedirect;
 use Liberu\ControlPanel\WebHosting\Actions\UpdateSubdomain;
 use Liberu\ControlPanel\WebHosting\Actions\UpdateVirtualHost;
+use Liberu\ControlPanel\WebHosting\Enums\WordPressOperationType;
 use Liberu\ControlPanel\WebHosting\Models\CronExecution;
 use Liberu\ControlPanel\WebHosting\Models\CronJob;
 use Liberu\ControlPanel\WebHosting\Models\Domain;
@@ -52,6 +57,8 @@ use Liberu\ControlPanel\WebHosting\Models\SslCertificate;
 use Liberu\ControlPanel\WebHosting\Models\Subdomain;
 use Liberu\ControlPanel\WebHosting\Models\VirtualHost;
 use Liberu\ControlPanel\WebHosting\Models\WebServer;
+use Liberu\ControlPanel\WebHosting\Models\WebsiteLaunch;
+use Liberu\ControlPanel\WebHosting\Models\WordPressOperation;
 use Liberu\ControlPanel\WebHosting\Queries\ApplicationStatistics;
 use Liberu\ControlPanel\WebHosting\Queries\ListDomains;
 use Liberu\ControlPanel\WebHosting\Queries\ListGitDeployments;
@@ -467,6 +474,35 @@ final class DomainController
         return response()->json(['data' => $check->execute($application)]);
     }
 
+    public function wordpressClone(Request $request, HostedApplication $application, CreateWordPressOperation $create): JsonResponse
+    {
+        return $this->createWordPressOperation($request, $application, WordPressOperationType::Clone, $create);
+    }
+
+    public function wordpressUpdateOperation(Request $request, HostedApplication $application, CreateWordPressOperation $create): JsonResponse
+    {
+        return $this->createWordPressOperation($request, $application, WordPressOperationType::Update, $create);
+    }
+
+    public function wordpressRollback(Request $request, HostedApplication $application, CreateWordPressOperation $create): JsonResponse
+    {
+        return $this->createWordPressOperation($request, $application, WordPressOperationType::Rollback, $create);
+    }
+
+    public function runWordPressOperation(Request $request, string $operation, RunWordPressOperation $run): JsonResponse
+    {
+        $item = WordPressOperation::query()->whereKey($operation)->where('team_id', $this->teamId($request))->firstOrFail();
+
+        return response()->json(['data' => self::wordpressOperationResource($run->execute($item))]);
+    }
+
+    public function showWordPressOperation(Request $request, string $operation): JsonResponse
+    {
+        $item = WordPressOperation::query()->whereKey($operation)->where('team_id', $this->teamId($request))->firstOrFail();
+
+        return response()->json(['data' => self::wordpressOperationResource($item)]);
+    }
+
     public function deployments(Request $request, ListGitDeployments $list): JsonResponse
     {
         $teamId = $request->user()?->current_team_id;
@@ -490,6 +526,32 @@ final class DomainController
         $deployment = $register->execute($domain, $data);
 
         return response()->json(['data' => self::deploymentResource($deployment)], 201);
+    }
+
+    public function launch(Request $request, Domain $domain, CreateWebsiteLaunch $create): JsonResponse
+    {
+        $this->assertTeam($request, $domain);
+        $data = $request->validate([
+            'node_id' => ['required', 'string', 'max:255'],
+            'idempotency_key' => ['required', 'string', 'max:255'],
+            'config' => ['sometimes', 'array'],
+        ]);
+
+        return response()->json(['data' => self::launchResource($create->execute($domain, array_merge($data, ['team_id' => $this->teamId($request)])))], 202);
+    }
+
+    public function runLaunch(Request $request, string $launch, RunWebsiteLaunch $run): JsonResponse
+    {
+        $item = WebsiteLaunch::query()->whereKey($launch)->where('team_id', $this->teamId($request))->firstOrFail();
+
+        return response()->json(['data' => self::launchResource($run->execute($item))]);
+    }
+
+    public function showLaunch(Request $request, string $launch): JsonResponse
+    {
+        $item = WebsiteLaunch::query()->whereKey($launch)->where('team_id', $this->teamId($request))->firstOrFail();
+
+        return response()->json(['data' => self::launchResource($item)]);
     }
 
     public function deploy(Request $request, string $deployment, RequestGitDeployment $requestDeployment): JsonResponse
@@ -638,6 +700,33 @@ final class DomainController
     private static function deploymentResource(GitDeployment $deployment): array
     {
         return ['id' => $deployment->getKey(), 'type' => 'control-panel-git-deployment', 'attributes' => $deployment->only(['domain_id', 'repository_url', 'repository_type', 'branch', 'deploy_path', 'use_oauth', 'status', 'auto_deploy', 'last_deployed_at', 'last_commit_hash'])];
+    }
+
+    /** @return array<string, mixed> */
+    private static function launchResource(WebsiteLaunch $launch): array
+    {
+        return ['id' => $launch->getKey(), 'type' => 'control-panel-website-launch', 'attributes' => $launch->only(['domain_id', 'node_id', 'idempotency_key', 'status', 'current_stage', 'config', 'result', 'steps', 'error', 'started_at', 'finished_at'])];
+    }
+
+    /** @return array<string, mixed> */
+    private static function wordpressOperationResource(WordPressOperation $operation): array
+    {
+        return ['id' => $operation->getKey(), 'type' => 'control-panel-wordpress-operation', 'attributes' => $operation->only(['application_id', 'target_application_id', 'operation', 'idempotency_key', 'status', 'result', 'error', 'started_at', 'finished_at'])];
+    }
+
+    private function createWordPressOperation(Request $request, HostedApplication $application, WordPressOperationType $type, CreateWordPressOperation $create): JsonResponse
+    {
+        $this->assertApplicationTeam($request, $application);
+        $data = $request->validate([
+            'idempotency_key' => ['required', 'string', 'max:255'],
+            'target_domain_id' => ['nullable', 'uuid'],
+            'target_application_id' => ['nullable', 'uuid'],
+            'name' => ['nullable', 'string', 'max:255'],
+            'document_root' => ['nullable', 'string', 'starts_with:/', 'max:2048'],
+            'config' => ['sometimes', 'array'],
+        ]);
+
+        return response()->json(['data' => self::wordpressOperationResource($create->execute($application, $type, array_merge($data, ['team_id' => $this->teamId($request)])))], 202);
     }
 
     /** @return array<string, mixed> */

--- a/modules/control-panel-web-hosting/src/WebHostingServiceProvider.php
+++ b/modules/control-panel-web-hosting/src/WebHostingServiceProvider.php
@@ -16,6 +16,8 @@ use Liberu\ControlPanel\WebHosting\Actions\CreateMimeType;
 use Liberu\ControlPanel\WebHosting\Actions\CreateRedirect;
 use Liberu\ControlPanel\WebHosting\Actions\CreateSubdomain;
 use Liberu\ControlPanel\WebHosting\Actions\CreateVirtualHost;
+use Liberu\ControlPanel\WebHosting\Actions\CreateWebsiteLaunch;
+use Liberu\ControlPanel\WebHosting\Actions\CreateWordPressOperation;
 use Liberu\ControlPanel\WebHosting\Actions\DeleteCronJob;
 use Liberu\ControlPanel\WebHosting\Actions\DeleteCustomErrorPage;
 use Liberu\ControlPanel\WebHosting\Actions\DeleteDirectoryProtection;
@@ -29,20 +31,28 @@ use Liberu\ControlPanel\WebHosting\Actions\RegisterGitDeployment;
 use Liberu\ControlPanel\WebHosting\Actions\RegisterHostingResource;
 use Liberu\ControlPanel\WebHosting\Actions\RemoveDirectoryProtectionUser;
 use Liberu\ControlPanel\WebHosting\Actions\RequestCertificate;
+use Liberu\ControlPanel\WebHosting\Actions\RunWebsiteLaunch;
+use Liberu\ControlPanel\WebHosting\Actions\RunWordPressOperation;
 use Liberu\ControlPanel\WebHosting\Actions\SaveCustomErrorPage;
 use Liberu\ControlPanel\WebHosting\Actions\SavePhpConfiguration;
 use Liberu\ControlPanel\WebHosting\Actions\SuspendDomain;
 use Liberu\ControlPanel\WebHosting\Actions\UpdateCronJob;
 use Liberu\ControlPanel\WebHosting\Actions\UpdateRedirect;
 use Liberu\ControlPanel\WebHosting\Actions\UpdateSubdomain;
+use Liberu\ControlPanel\WebHosting\Contracts\WebsiteLaunchExecutor;
+use Liberu\ControlPanel\WebHosting\Contracts\WordPressLifecycleExecutor;
 use Liberu\ControlPanel\WebHosting\Queries\ListDomains;
 use Liberu\ControlPanel\WebHosting\Queries\ListGitDeployments;
 use Liberu\ControlPanel\WebHosting\Queries\ListResourceUsage;
+use Liberu\ControlPanel\WebHosting\Services\UnavailableWebsiteLaunchExecutor;
+use Liberu\ControlPanel\WebHosting\Services\UnavailableWordPressLifecycleExecutor;
 
 final class WebHostingServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->app->scoped(WebsiteLaunchExecutor::class, UnavailableWebsiteLaunchExecutor::class);
+        $this->app->scoped(WordPressLifecycleExecutor::class, UnavailableWordPressLifecycleExecutor::class);
         $this->app->scoped(AddDirectoryProtectionUser::class);
         $this->app->scoped(ConfigureHotlinkProtection::class);
         $this->app->scoped(CreateDirectoryProtection::class);
@@ -76,6 +86,10 @@ final class WebHostingServiceProvider extends ServiceProvider
         $this->app->scoped(SavePhpConfiguration::class);
         $this->app->scoped(SuspendDomain::class);
         $this->app->scoped(UpdateRedirect::class);
+        $this->app->scoped(CreateWebsiteLaunch::class);
+        $this->app->scoped(RunWebsiteLaunch::class);
+        $this->app->scoped(CreateWordPressOperation::class);
+        $this->app->scoped(RunWordPressOperation::class);
     }
 
     public function boot(): void

--- a/modules/import-export/src/ImportExportServiceProvider.php
+++ b/modules/import-export/src/ImportExportServiceProvider.php
@@ -3,11 +3,45 @@
 namespace Liberu\Foundation\ImportExport;
 
 use Illuminate\Support\ServiceProvider;
+use Liberu\Foundation\ImportExport\Actions\CreateHostingMigration;
+use Liberu\Foundation\ImportExport\Actions\RunHostingMigration;
+use Liberu\Foundation\ImportExport\Contracts\HostingMigrationExecutor;
+use Liberu\Foundation\ImportExport\Contracts\MigrationDatabaseConnection;
+use Liberu\Foundation\ImportExport\Contracts\MigrationDnsRecordWriter;
+use Liberu\Foundation\ImportExport\Contracts\MigrationMailboxWriter;
+use Liberu\Foundation\ImportExport\Services\BindDnsMigrationExecutor;
+use Liberu\Foundation\ImportExport\Services\HostingMigrationArchive;
+use Liberu\Foundation\ImportExport\Services\MboxMailMigrationExecutor;
+use Liberu\Foundation\ImportExport\Services\SqlDatabaseMigrationExecutor;
+use Liberu\Foundation\ImportExport\Services\UnavailableHostingMigrationExecutor;
+use Liberu\Foundation\ImportExport\Services\UnavailableMigrationDatabaseConnection;
+use Liberu\Foundation\ImportExport\Services\UnavailableMigrationDnsRecordWriter;
+use Liberu\Foundation\ImportExport\Services\UnavailableMigrationMailboxWriter;
 
 final class ImportExportServiceProvider extends ServiceProvider
 {
+    public function register(): void
+    {
+        $this->app->scoped(HostingMigrationArchive::class);
+        $this->app->scoped(HostingMigrationExecutor::class, UnavailableHostingMigrationExecutor::class);
+        $this->app->scoped(MigrationDatabaseConnection::class, UnavailableMigrationDatabaseConnection::class);
+        $this->app->scoped(MigrationDnsRecordWriter::class, UnavailableMigrationDnsRecordWriter::class);
+        $this->app->scoped(MigrationMailboxWriter::class, UnavailableMigrationMailboxWriter::class);
+        $this->app->scoped(CreateHostingMigration::class);
+        $this->app->scoped(RunHostingMigration::class);
+        $this->app->scoped(SqlDatabaseMigrationExecutor::class);
+        $this->app->scoped(BindDnsMigrationExecutor::class);
+        $this->app->scoped(MboxMailMigrationExecutor::class);
+    }
+
     public function boot(): void
     {
+        if (class_exists('App\\Hosting\\Migrations\\ControlPanelDnsRecordWriter')) {
+            $this->app->scoped(MigrationDnsRecordWriter::class, 'App\\Hosting\\Migrations\\ControlPanelDnsRecordWriter');
+        }
+        if (class_exists('App\\Hosting\\Migrations\\ControlPanelMailboxWriter')) {
+            $this->app->scoped(MigrationMailboxWriter::class, 'App\\Hosting\\Migrations\\ControlPanelMailboxWriter');
+        }
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 }

--- a/tests/Feature/KubernetesModuleTest.php
+++ b/tests/Feature/KubernetesModuleTest.php
@@ -45,6 +45,14 @@ it('rejects unknown Kubernetes assets', function (): void {
     expect(fn () => app(RegisterKubernetesAsset::class)->execute(['team_id' => 'team-1', 'kind' => 'unknown']))->toThrow(ValidationException::class);
 });
 
+it('validates autoscaler targets, bounds, and metrics', function (): void {
+    $action = app(RegisterKubernetesAsset::class);
+    expect(fn () => $action->execute(['team_id' => 'team-1', 'kind' => 'autoscaling', 'name' => 'web', 'target' => 'deployment/web', 'min_replicas' => 5, 'max_replicas' => 2]))->toThrow(ValidationException::class);
+    expect(fn () => $action->execute(['team_id' => 'team-1', 'kind' => 'autoscaling', 'name' => 'web', 'target' => 'deployment/web', 'min_replicas' => 1, 'max_replicas' => 2, 'metric' => 'latency']))->toThrow(ValidationException::class);
+    $autoscaler = $action->execute(['team_id' => 'team-1', 'kind' => 'autoscaling', 'name' => 'web', 'target' => 'deployment/web', 'min_replicas' => 1, 'max_replicas' => 2, 'metric' => 'MEMORY']);
+    expect($autoscaler->metric)->toBe('memory');
+});
+
 it('lists Kubernetes assets for the current team', function (): void {
     $team = Team::factory()->create();
     $otherTeam = Team::factory()->create();

--- a/tests/Feature/LocalFileBackupsTest.php
+++ b/tests/Feature/LocalFileBackupsTest.php
@@ -2,6 +2,7 @@
 
 use App\Hosting\Backups\EncryptedFileArchive;
 use App\Hosting\Backups\LocalFileBackups;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Liberu\ControlPanel\Backups\Actions\CreatePolicy;
@@ -160,6 +161,39 @@ it('executes the operator backup and restore commands', function (): void {
     $this->artisan('hosting:restore-files', ['snapshot' => $snapshot->getKey(), '--team' => 'team-1'])->assertSuccessful();
     $this->artisan('hosting:restore-files', ['snapshot' => $snapshot->getKey()])->assertFailed();
     $this->artisan('hosting:backup-files', ['source' => 'missing'])->assertFailed();
+    $this->artisan('hosting:restore-files', ['snapshot' => $snapshot->getKey(), '--team' => 'another-team'])->assertFailed();
+});
+
+it('refuses the backup command when the module is disabled', function (): void {
+    $providers = new ReflectionProperty(app(), 'loadedProviders');
+    $loaded = $providers->getValue(app());
+    $disabled = $loaded;
+    unset($disabled[BackupsServiceProvider::class]);
+    $providers->setValue(app(), $disabled);
+    try {
+        $this->artisan('hosting:backup-files', ['source' => 'fixture'])
+            ->expectsOutput('Enable the control-panel-backups module before executing backups.')->assertFailed();
+    } finally {
+        $providers->setValue(app(), $loaded);
+    }
+});
+
+it('removes the new private restore directory if recording completion fails', function (): void {
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    $event = 'eloquent.updating: '.BackupRestore::class;
+    Event::listen($event, function (BackupRestore $restore): void {
+        if ($restore->getAttribute('status')->value === 'completed') {
+            throw new RuntimeException('Simulated completion write failure');
+        }
+    });
+    try {
+        expect(fn () => app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-1'))->toThrow(RuntimeException::class);
+        $restore = BackupRestore::query()->firstOrFail();
+        expect($restore->getAttribute('status')->value)->toBe('failed')
+            ->and(is_dir($restore->getAttribute('target')))->toBeFalse();
+    } finally {
+        Event::forget($event);
+    }
 });
 
 it('authenticates the owning team as well as the archive bytes', function (): void {

--- a/tests/Feature/LocalFileBackupsTest.php
+++ b/tests/Feature/LocalFileBackupsTest.php
@@ -1,0 +1,194 @@
+<?php
+
+use App\Hosting\Backups\EncryptedFileArchive;
+use App\Hosting\Backups\LocalFileBackups;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Liberu\ControlPanel\Backups\Actions\CreatePolicy;
+use Liberu\ControlPanel\Backups\BackupsServiceProvider;
+use Liberu\ControlPanel\Backups\Enums\RestoreStatus;
+use Liberu\ControlPanel\Backups\Enums\SnapshotStatus;
+use Liberu\ControlPanel\Backups\Models\BackupRestore;
+use Liberu\ControlPanel\Backups\Models\BackupSnapshot;
+
+beforeEach(function (): void {
+    app()->register(BackupsServiceProvider::class);
+    $this->artisan('migrate');
+    $this->backupTestRoot = sys_get_temp_dir().'/hosting-backup-tests-'.Str::uuid();
+    foreach (['source', 'archives', 'restores'] as $directory) {
+        File::ensureDirectoryExists($this->backupTestRoot.'/'.$directory, 0700);
+        chmod($this->backupTestRoot.'/'.$directory, 0700);
+    }
+    $this->policy = app(CreatePolicy::class)->execute(['team_id' => 'team-1', 'name' => 'Fixture files', 'storage_driver' => 'local-files-v1']);
+    $this->backupKey = Str::random(64);
+    config([
+        'hosting-backups.archive_root' => $this->backupTestRoot.'/archives',
+        'hosting-backups.restore_root' => $this->backupTestRoot.'/restores',
+        'hosting-backups.keys' => ['v1' => $this->backupKey],
+        'hosting-backups.sources' => ['fixture' => ['team_id' => 'team-1', 'policy_id' => $this->policy->getKey(), 'path' => $this->backupTestRoot.'/source']],
+    ]);
+    File::put($this->backupTestRoot.'/source/index.html', 'A real website fixture with private content.');
+});
+
+afterEach(function (): void {
+    if (isset($this->backupTestRoot)) {
+        File::deleteDirectory($this->backupTestRoot);
+    }
+});
+
+it('encrypts, verifies and restores actual file bytes and empty directories', function (): void {
+    File::ensureDirectoryExists($this->backupTestRoot.'/source/empty', 0700);
+    File::put($this->backupTestRoot.'/source/.env', 'EXAMPLE=fixture-only');
+    $binary = random_bytes(1024 * 1024);
+    File::put($this->backupTestRoot.'/source/日本語.bin', $binary);
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    $archive = $this->backupTestRoot.'/archives/'.$snapshot->location;
+
+    expect($snapshot->status)->toBe(SnapshotStatus::Verified)
+        ->and($snapshot->checksum)->toBe(hash_file('sha256', $archive))
+        ->and(fileperms($archive) & 0777)->toBe(0600)
+        ->and(File::get($archive))->not->toContain('A real website fixture with private content.')
+        ->and(json_encode($snapshot))->not->toContain($this->backupKey);
+    $zip = new ZipArchive();
+    $zip->open($archive);
+    expect($zip->statName('files/index.html')['encryption_method'])->toBe(ZipArchive::EM_AES_256);
+    $zip->close();
+
+    File::put($this->backupTestRoot.'/source/index.html', 'New live content');
+    $restore = app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-1');
+    expect($restore->status)->toBe(RestoreStatus::Completed)
+        ->and(File::get($restore->target.'/index.html'))->toBe('A real website fixture with private content.')
+        ->and(File::get($restore->target.'/日本語.bin'))->toBe($binary)
+        ->and(File::get($restore->target.'/.env'))->toBe('EXAMPLE=fixture-only')
+        ->and(is_dir($restore->target.'/empty'))->toBeTrue()
+        ->and(File::get($this->backupTestRoot.'/source/index.html'))->toBe('New live content')
+        ->and(fileperms($restore->target.'/index.html') & 0777)->toBe(0600);
+    $again = app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-1');
+    expect($again->target)->not->toBe($restore->target);
+});
+
+it('rejects altered archives before restoring and records the failure', function (): void {
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    File::append($this->backupTestRoot.'/archives/'.$snapshot->location, 'corruption');
+    expect(fn () => app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-1'))->toThrow(RuntimeException::class, 'integrity');
+    expect(BackupRestore::query()->first()->status)->toBe(RestoreStatus::Failed)
+        ->and(File::directories($this->backupTestRoot.'/restores'))->toBe([]);
+});
+
+it('does not restore another teams snapshot', function (): void {
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    expect(fn () => app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-2'))->toThrow(RuntimeException::class);
+    expect(BackupRestore::query()->count())->toBe(0);
+});
+
+it('requires the original authentication key even if the checksum is replaced', function (): void {
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    config(['hosting-backups.keys.v1' => Str::random(64)]);
+    expect(fn () => app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-1'))->toThrow(RuntimeException::class, 'authentication');
+});
+
+it('keeps older snapshots restorable after rotating the active key', function (): void {
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    config(['hosting-backups.active_key' => 'v2', 'hosting-backups.keys.v2' => Str::random(64)]);
+    $new = app(LocalFileBackups::class)->backup('fixture');
+    expect($new->metadata['key_id'])->toBe('v2')
+        ->and(app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-1')->status)->toBe(RestoreStatus::Completed);
+});
+
+it('refuses sources outside the operator allowlist', function (): void {
+    expect(fn () => app(LocalFileBackups::class)->backup('/etc'))->toThrow(RuntimeException::class);
+    expect(BackupSnapshot::query()->count())->toBe(0);
+});
+
+it('requires an active encrypted policy owned by the configured team', function (array $changes): void {
+    $this->policy->forceFill($changes)->save();
+    expect(fn () => app(LocalFileBackups::class)->backup('fixture'))->toThrow(RuntimeException::class);
+    expect(BackupSnapshot::query()->count())->toBe(0);
+})->with([
+    [['active' => false]], [['encrypted' => false]], [['team_id' => 'other-team']], [['storage_driver' => 's3']],
+]);
+
+it('rejects source symlinks and hard links instead of reading their targets', function (bool $hard): void {
+    $outside = $this->backupTestRoot.'/outside.txt';
+    File::put($outside, 'Do not back up this data');
+    $link = $this->backupTestRoot.'/source/link';
+    $hard ? link($outside, $link) : symlink($outside, $link);
+    expect(fn () => app(LocalFileBackups::class)->backup('fixture'))->toThrow(RuntimeException::class);
+    expect(BackupSnapshot::query()->first()->status)->toBe(SnapshotStatus::Failed)
+        ->and(File::allFiles($this->backupTestRoot.'/archives'))->toHaveCount(0)
+        ->and(File::get($outside))->toBe('Do not back up this data');
+})->with([false, true]);
+
+it('enforces archive size and entry limits', function (string $limit): void {
+    config(['hosting-backups.'.$limit => 1]);
+    File::put($this->backupTestRoot.'/source/second.txt', 'second file');
+    expect(fn () => app(LocalFileBackups::class)->backup('fixture'))->toThrow(RuntimeException::class);
+    expect(BackupSnapshot::query()->first()->status)->toBe(SnapshotStatus::Failed);
+})->with(['max_bytes', 'max_files', 'max_manifest_bytes']);
+
+it('requires private non-overlapping storage directories and a configured key', function (string $case): void {
+    match ($case) {
+        'public' => chmod($this->backupTestRoot.'/archives', 0755),
+        'overlap' => config(['hosting-backups.archive_root' => $this->backupTestRoot.'/source']),
+        'key' => config(['hosting-backups.keys' => []]),
+        'root' => config(['hosting-backups.archive_root' => '/']),
+    };
+    expect(fn () => app(LocalFileBackups::class)->backup('fixture'))->toThrow(RuntimeException::class);
+    expect(BackupSnapshot::query()->count())->toBe(0);
+})->with(['public', 'overlap', 'key', 'root']);
+
+it('rejects traversal and absolute paths even inside an authenticated archive', function (string $path): void {
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    $archive = $this->backupTestRoot.'/archives/'.$snapshot->location;
+    $zip = new ZipArchive();
+    $zip->open($archive, ZipArchive::OVERWRITE);
+    $zip->addFromString('manifest.json', json_encode(['version' => 1, 'entries' => [$path => ['type' => 'file', 'size' => 1, 'sha256' => hash('sha256', 'x')]]], JSON_THROW_ON_ERROR));
+    $zip->addFromString('files/'.$path, 'x');
+    $password = bin2hex(hash_hkdf('sha256', $this->backupKey, 32, 'hosting-backups:encryption:v1'));
+    $zip->setEncryptionName('manifest.json', ZipArchive::EM_AES_256, $password);
+    $zip->setEncryptionName('files/'.$path, ZipArchive::EM_AES_256, $password);
+    $zip->close();
+    $context = json_encode(['team' => 'team-1', 'snapshot' => (string) $snapshot->getKey()], JSON_THROW_ON_ERROR);
+    $snapshot->forceFill(['checksum' => hash_file('sha256', $archive), 'metadata' => [...$snapshot->metadata, 'signature' => app(EncryptedFileArchive::class)->signature($archive, $this->backupKey, $context)]])->save();
+    expect(fn () => app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-1'))->toThrow(RuntimeException::class, 'Unsafe archive path');
+    expect(File::directories($this->backupTestRoot.'/restores'))->toBe([]);
+})->with(['../escape', '/absolute', 'safe/../../escape', 'C:\\escape', 'safe//file']);
+
+it('executes the operator backup and restore commands', function (): void {
+    $this->artisan('hosting:backup-files', ['source' => 'fixture'])->assertSuccessful();
+    $snapshot = BackupSnapshot::query()->first();
+    $this->artisan('hosting:restore-files', ['snapshot' => $snapshot->getKey(), '--team' => 'team-1'])->assertSuccessful();
+    $this->artisan('hosting:restore-files', ['snapshot' => $snapshot->getKey()])->assertFailed();
+    $this->artisan('hosting:backup-files', ['source' => 'missing'])->assertFailed();
+});
+
+it('authenticates the owning team as well as the archive bytes', function (): void {
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    $snapshot->forceFill(['team_id' => 'team-2'])->save();
+    expect(fn () => app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-2'))->toThrow(RuntimeException::class, 'authentication');
+});
+
+it('backs up and restores an empty directory tree', function (): void {
+    File::delete($this->backupTestRoot.'/source/index.html');
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    $restore = app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-1');
+    expect($restore->status)->toBe(RestoreStatus::Completed)->and(File::allFiles($restore->target))->toBe([]);
+});
+
+it('verifies per-file checksums even when the whole archive is authenticated', function (): void {
+    $snapshot = app(LocalFileBackups::class)->backup('fixture');
+    $archive = $this->backupTestRoot.'/archives/'.$snapshot->location;
+    $password = bin2hex(hash_hkdf('sha256', $this->backupKey, 32, 'hosting-backups:encryption:v1'));
+    $zip = new ZipArchive();
+    $zip->open($archive);
+    $zip->setPassword($password);
+    $manifest = json_decode($zip->getFromName('manifest.json'), true, flags: JSON_THROW_ON_ERROR);
+    $manifest['entries']['index.html']['sha256'] = str_repeat('0', 64);
+    $zip->addFromString('manifest.json', json_encode($manifest, JSON_THROW_ON_ERROR));
+    $zip->setEncryptionName('manifest.json', ZipArchive::EM_AES_256, $password);
+    $zip->close();
+    $context = json_encode(['team' => 'team-1', 'snapshot' => (string) $snapshot->getKey()], JSON_THROW_ON_ERROR);
+    $snapshot->forceFill(['checksum' => hash_file('sha256', $archive), 'metadata' => [...$snapshot->metadata, 'signature' => app(EncryptedFileArchive::class)->signature($archive, $this->backupKey, $context)]])->save();
+    expect(fn () => app(LocalFileBackups::class)->restore((string) $snapshot->getKey(), 'team-1'))->toThrow(RuntimeException::class, 'checksum');
+    expect(File::directories($this->backupTestRoot.'/restores'))->toBe([]);
+});


### PR DESCRIPTION
Adds an opt-in operator-only local-file backup executor using configured source aliases and the existing backup snapshot/restore records. Encrypts files and manifest with AES-256 ZIP, verifies per-file SHA-256 checksums by reading the archive, authenticates archive/team/snapshot with separately derived HMAC keys, and verifies restored files read back from disk. Restores use newly generated private directories and never replace live sites. Rejects unsafe paths, symlinks/hardlinks, incorrect ownership, corrupt archives, unconfigured keys, overlapping roots and resource limits. Includes two Artisan commands, deployment documentation and real filesystem/ZIP regression fixtures. Validation: full local suite 583 passed / 12 existing skips; latest focused backup suite 28 passed; Pint and PHPStan pass. No live user data touched. File-only scope: database consistency, remote/offsite storage, retention, scheduling and panel-driven execution remain further work.